### PR TITLE
Refactor convert_data_to_args function to delete print statements

### DIFF
--- a/recsa/loading/structure_data.py
+++ b/recsa/loading/structure_data.py
@@ -84,9 +84,5 @@ def convert_data_to_args(data: StructureData) -> Args:
     }
     components = {comp.id: comp.kind for comp in data.components}
     bonds = {bond.id: frozenset(bond.bindsites) for bond in data.bonds or []}
-
-    print(component_structures)
-    print(components)
-    print(bonds)
     
     return Args(component_structures, components, bonds)


### PR DESCRIPTION
This pull request includes a minor change to the `recsa/loading/structure_data.py` file. The change involves removing debug print statements from the `convert_data_to_args` function to clean up the code.

Code cleanup:

* [`recsa/loading/structure_data.py`](diffhunk://#diff-0613ae287399e247f8116e1a7f7482dc296b4b2895bc490baf11d91c5dc713a6L88-L91): Removed debug print statements that output `component_structures`, `components`, and `bonds` in the `convert_data_to_args` function.