### PR TITLE
Update version to 0.1.2 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "recsa"
-version = "0.1.0"
+version = "0.1.2"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
This pull request includes a minor version update for the `recsa` project in the `pyproject.toml` file. The version has been updated from `0.1.0` to `0.1.2`.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated project version from `0.1.0` to `0.1.2`.