### PR TITLE
Add FrozenUnorderedPair class to recsa.utils

### DIFF
--- a/recsa/utils/__init__.py
+++ b/recsa/utils/__init__.py
@@ -1,5 +1,6 @@
 from .custom_zip import *
 from .cyclic_perm import *
+from .frozen_unordered_pair import *
 from .mapping_iterable_comparison import *
 from .nested_dict_update import *
 from .node_equivalence import *

--- a/recsa/utils/frozen_unordered_pair.py
+++ b/recsa/utils/frozen_unordered_pair.py
@@ -1,0 +1,50 @@
+from collections.abc import Hashable, Iterable
+from typing import Generic, TypeVar, overload
+
+import recsa as rx
+
+__all__ = ['FrozenUnorderedPair']
+
+
+T = TypeVar('T', bound=Hashable)
+
+
+class FrozenUnorderedPair(Generic[T]):
+    """A frozen unordered pair of two hashable elements."""
+    @overload
+    def __init__(self, first: T, second: T) -> None: ...
+    @overload
+    def __init__(self, pair: Iterable[T]) -> None: ...
+    def __init__(self, *args):
+        # TODO: Add type validation.
+        if len(args) == 1:
+            pair = tuple(args[0])
+            if len(pair) != 2:
+                raise rx.RecsaValueError('The pair should have two elements.')
+            self.__pair = pair
+        elif len(args) == 2:
+            self.__pair = tuple(args)
+        else:
+            raise rx.RecsaValueError('The pair should have two elements.')
+    
+    @property
+    def first(self) -> T:
+        return self.__pair[0]
+    
+    @property
+    def second(self) -> T:
+        return self.__pair[1]
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FrozenUnorderedPair):
+            return False
+        return set(self.__pair) == set(other.__pair)
+    
+    def __hash__(self) -> int:
+        return hash(frozenset(self.__pair))
+    
+    def __repr__(self) -> str:
+        return f'FrozenUnorderedPair({self.__pair})'
+    
+    def __iter__(self):
+        return iter(self.__pair)

--- a/recsa/utils/tests/test_frozen_unordered_pair.py
+++ b/recsa/utils/tests/test_frozen_unordered_pair.py
@@ -1,0 +1,59 @@
+import pytest
+
+import recsa as rx
+from recsa.utils.frozen_unordered_pair import FrozenUnorderedPair
+
+
+def test_init_with_two_elements():
+    pair = FrozenUnorderedPair(1, 2)
+    assert pair.first == 1
+    assert pair.second == 2
+
+
+def test_init_with_iterable():
+    pair = FrozenUnorderedPair([1, 2])
+    assert pair.first == 1
+    assert pair.second == 2
+
+
+def test_init_with_invalid_iterable_length():
+    with pytest.raises(rx.RecsaValueError):
+        FrozenUnorderedPair([1])
+
+
+def test_init_with_invalid_number_of_arguments():
+    with pytest.raises(rx.RecsaValueError):
+        FrozenUnorderedPair(1, 2, 3)  # type: ignore
+
+
+def test_equality():
+    pair1 = FrozenUnorderedPair(1, 2)
+    pair2 = FrozenUnorderedPair(2, 1)
+    assert pair1 == pair2
+
+
+def test_inequality():
+    pair1 = FrozenUnorderedPair(1, 2)
+    pair2 = FrozenUnorderedPair(1, 3)
+    assert pair1 != pair2
+
+
+def test_hash():
+    pair1 = FrozenUnorderedPair(1, 2)
+    pair2 = FrozenUnorderedPair(2, 1)
+    assert hash(pair1) == hash(pair2)
+
+
+def test_repr():
+    pair = FrozenUnorderedPair(1, 2)
+    assert repr(pair) == 'FrozenUnorderedPair((1, 2))'
+
+
+def test_iteration():
+    pair = FrozenUnorderedPair(1, 2)
+    elements = list(pair)
+    assert elements == [1, 2]
+
+
+if __name__ == '__main__':
+    pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request introduces a new utility class `FrozenUnorderedPair` to the `recsa/utils` module and includes tests for this class. The most important changes are the addition of the `FrozenUnorderedPair` class and its corresponding unit tests.

### New Utility Class:
* [`recsa/utils/frozen_unordered_pair.py`](diffhunk://#diff-831c7f32e232f9bac0cf2cffb9187a646d080d9c15ea7e2d27bbdb798f44b931R1-R50): Added the `FrozenUnorderedPair` class, which represents a frozen unordered pair of two hashable elements. This class includes methods for initialization, equality comparison, hashing, representation, and iteration.

### Updates to Module Initialization:
* [`recsa/utils/__init__.py`](diffhunk://#diff-fe151ada519bd210d4b01bb37b69f794542ff851ed38795c60492b42c20fdfd6R3): Included the new `FrozenUnorderedPair` class in the module's exports.

### Unit Tests:
* [`recsa/utils/tests/test_frozen_unordered_pair.py`](diffhunk://#diff-38b1a054da390d3708075d076715772ed1ff0048575ef3fdae4279e4343496e4R1-R59): Added unit tests for the `FrozenUnorderedPair` class to ensure proper functionality, including tests for initialization, equality, hashing, representation, and iteration.