### PR TITLE
Refactor class name LocalAuxEdge to AuxEdge

### DIFF
--- a/recsa/algorithms/isomorphism/tests/test_isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/tests/test_isomorphism_check.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import pytest
 
-from recsa import Assembly, ComponentStructure, LocalAuxEdge, is_isomorphic
+from recsa import Assembly, AuxEdge, ComponentStructure, is_isomorphic
 
 
 @pytest.fixture
@@ -19,8 +19,8 @@ def component_structures() -> dict[str, ComponentStructure]:
     M_COMP = ComponentStructure(
         'M', {'a', 'b', 'c', 'd'},
         {
-            LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-            LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis'),})
+            AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+            AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis'),})
     L_COMP = ComponentStructure('L', {'a', 'b'})
     X_COMP = ComponentStructure('X', {'a'})
     return {'M': M_COMP, 'L': L_COMP, 'X': X_COMP}

--- a/recsa/algorithms/isomorphism/tests/test_iteration.py
+++ b/recsa/algorithms/isomorphism/tests/test_iteration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from recsa import Assembly, ComponentStructure, LocalAuxEdge, isomorphisms_iter
+from recsa import Assembly, AuxEdge, ComponentStructure, isomorphisms_iter
 
 
 def test_isomorphisms_iter():
@@ -10,8 +10,8 @@ def test_isomorphisms_iter():
     COMPONENT_STRUCTURES = {
         'M': ComponentStructure(
             'M', {'a', 'b', 'c', 'd'},
-            {LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-             LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis')}),
+            {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
         'L': ComponentStructure('L', {'a'}),
         'X': ComponentStructure('X', {'a'})}
     

--- a/recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import pytest
 
-from recsa import Assembly, ComponentStructure, LocalAuxEdge
+from recsa import Assembly, AuxEdge, ComponentStructure
 from recsa.algorithms.isomorphism import pure_is_isomorphic
 
 
@@ -20,8 +20,8 @@ def component_structures() -> dict[str, ComponentStructure]:
     M_COMP = ComponentStructure(
         'M', {'a', 'b', 'c', 'd'},
         {
-            LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-            LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis'),})
+            AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+            AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis'),})
     L_COMP = ComponentStructure('L', {'a', 'b'})
     X_COMP = ComponentStructure('X', {'a'})
     return {'M': M_COMP, 'L': L_COMP, 'X': X_COMP}

--- a/recsa/algorithms/tests/test_aux_edge_existence.py
+++ b/recsa/algorithms/tests/test_aux_edge_existence.py
@@ -1,6 +1,6 @@
 import pytest
 
-from recsa import Assembly, ComponentStructure, LocalAuxEdge, has_aux_edges
+from recsa import Assembly, AuxEdge, ComponentStructure, has_aux_edges
 
 
 def test_has_aux_edges_true():
@@ -10,8 +10,8 @@ def test_has_aux_edges_true():
     COMPONENT_STRUCTURES = {
         'M': ComponentStructure(
             'M', {'a', 'b', 'c', 'd'}, 
-            {LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-             LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis')}),
+            {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
         'X': ComponentStructure('X', {'a'})}
     assert has_aux_edges(MX4, COMPONENT_STRUCTURES)
 
@@ -34,8 +34,8 @@ def test_has_aux_edges_false2():
         'M': ComponentStructure('M', {'a', 'b', 'c', 'd'}),  # No aux edges
         'L': ComponentStructure(
             'L', {'a', 'b', 'c', 'd'},
-            {LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-             LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis')}),  # Aux edges but not in assembly
+            {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),  # Aux edges but not in assembly
         'X': ComponentStructure('X', {'a'})}
     assert not has_aux_edges(MX4, COMPONENT_STRUCTURES)
 

--- a/recsa/assembly_drawing/tests/test_drawing_2d.py
+++ b/recsa/assembly_drawing/tests/test_drawing_2d.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import pytest
 
-from recsa import Assembly, ComponentStructure, LocalAuxEdge, draw_2d
+from recsa import Assembly, AuxEdge, ComponentStructure, draw_2d
 
 
 @pytest.mark.skip(reason='This is a visual test.')
@@ -13,8 +13,8 @@ def test_draw_2d():
     COMPONENT_STRUCTURES = {
         'M': ComponentStructure(
             'M', {'a', 'b', 'c', 'd'}, {
-                LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-                LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis')}),
+                AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+                AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
         'L': ComponentStructure('L', {'a', 'b'}),
         'X': ComponentStructure('X', {'a'}),
     }

--- a/recsa/assembly_drawing/tests/test_drawing_3d.py
+++ b/recsa/assembly_drawing/tests/test_drawing_3d.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import pytest
 
-from recsa import Assembly, ComponentStructure, LocalAuxEdge, draw_3d
+from recsa import Assembly, AuxEdge, ComponentStructure, draw_3d
 
 
 @pytest.mark.skip(reason='This is a visual test.')
@@ -13,8 +13,8 @@ def test_draw_3d():
     COMPONENT_STRUCTURES = {
         'M': ComponentStructure(
             'M', {'a', 'b', 'c', 'd'}, {
-                LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-                LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis')}),
+                AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+                AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
         'L': ComponentStructure('L', {'a', 'b'}),
         'X': ComponentStructure('X', {'a'}),
     }

--- a/recsa/classes/__init__.py
+++ b/recsa/classes/__init__.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 
 from .assembly import Assembly
-from .aux_edge import LocalAuxEdge
+from .aux_edge import AuxEdge
 from .component_structure import ComponentStructure
 from .mle import MleBindsite
 from .mle import MleKind

--- a/recsa/classes/assembly.py
+++ b/recsa/classes/assembly.py
@@ -12,7 +12,7 @@ import networkx as nx
 
 from recsa import RecsaValueError
 
-from .aux_edge import LocalAuxEdge
+from .aux_edge import AuxEdge
 from .bindsite_id_converter import BindsiteIdConverter
 from .component_structure import ComponentStructure
 

--- a/recsa/classes/aux_edge.py
+++ b/recsa/classes/aux_edge.py
@@ -6,10 +6,10 @@ from recsa.utils import FrozenUnorderedPair
 from .validations import (validate_name_of_aux_type,
                           validate_name_of_binding_site)
 
-__all__ = ['LocalAuxEdge']
+__all__ = ['AuxEdge']
 
 
-class LocalAuxEdge:
+class AuxEdge:
     """An auxiliary edge between two binding sites. (Immutable)"""
     def __init__(
             self, local_bindsite1: str, local_bindsite2: str, aux_kind: str):
@@ -67,7 +67,7 @@ class LocalAuxEdge:
         return hash((self.bindsites, self.aux_kind))
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, LocalAuxEdge):
+        if not isinstance(other, AuxEdge):
             return False
         return (
             self.bindsites == other.bindsites and

--- a/recsa/classes/component_structure/bindsite_existence_check.py
+++ b/recsa/classes/component_structure/bindsite_existence_check.py
@@ -1,12 +1,12 @@
 from recsa import RecsaValueError
 
-from ..aux_edge import LocalAuxEdge
+from ..aux_edge import AuxEdge
 
 __all__ = ['check_bindsites_of_aux_edges_exists']
 
 
 def check_bindsites_of_aux_edges_exists(
-        aux_edges: set[LocalAuxEdge], binding_sites: set[str]) -> None:
+        aux_edges: set[AuxEdge], binding_sites: set[str]) -> None:
     """Check if the binding sites of the auxiliary edges exist in the
     binding sites of the component.
     """

--- a/recsa/classes/component_structure/component_structure.py
+++ b/recsa/classes/component_structure/component_structure.py
@@ -6,7 +6,7 @@ import networkx as nx
 
 from recsa import RecsaValueError
 
-from ..aux_edge import LocalAuxEdge
+from ..aux_edge import AuxEdge
 from ..validations import (validate_name_of_binding_site,
                            validate_name_of_component_kind)
 from .bindsite_existence_check import check_bindsites_of_aux_edges_exists
@@ -20,7 +20,7 @@ class ComponentStructure:
     def __init__(
             self, component_kind: str, 
             binding_sites: set[str],
-            aux_edges: set[LocalAuxEdge] | None = None):
+            aux_edges: set[AuxEdge] | None = None):
         """
         Parameters
         ----------
@@ -87,7 +87,7 @@ class ComponentStructure:
         return self.__binding_sites.copy()
 
     @property
-    def aux_edges(self) -> set[LocalAuxEdge]:
+    def aux_edges(self) -> set[AuxEdge]:
         # TODO: Consider not to make a deep copy. It's costly.
         return deepcopy(self.__aux_edges)
     
@@ -138,7 +138,7 @@ class ComponentStructure:
             self.__remove_binding_site(bindsite)
 
     @clear_g_cache
-    def __add_aux_edge(self, aux_edge: LocalAuxEdge) -> None:
+    def __add_aux_edge(self, aux_edge: AuxEdge) -> None:
         """Add an auxiliary edge."""
         if aux_edge in self.__aux_edges:
             raise RecsaValueError(
@@ -150,13 +150,13 @@ class ComponentStructure:
         self.__aux_edges.add(aux_edge)
     
     @clear_g_cache
-    def __add_aux_edges(self, aux_edges: set[LocalAuxEdge]) -> None:
+    def __add_aux_edges(self, aux_edges: set[AuxEdge]) -> None:
         """Add auxiliary edges."""
         for aux_edge in aux_edges:
             self.__add_aux_edge(aux_edge)
     
     @clear_g_cache
-    def __remove_aux_edge(self, aux_edge: LocalAuxEdge) -> None:
+    def __remove_aux_edge(self, aux_edge: AuxEdge) -> None:
         """Remove an auxiliary edge."""
         if aux_edge not in self.__aux_edges:
             raise RecsaValueError(
@@ -164,7 +164,7 @@ class ComponentStructure:
         self.__aux_edges.remove(aux_edge)
 
     @clear_g_cache
-    def __remove_aux_edges(self, aux_edges: set[LocalAuxEdge]) -> None:
+    def __remove_aux_edges(self, aux_edges: set[AuxEdge]) -> None:
         """Remove auxiliary edges."""
         for aux_edge in aux_edges:
             self.__remove_aux_edge(aux_edge)

--- a/recsa/classes/component_structure/tests/test_component_structure.py
+++ b/recsa/classes/component_structure/tests/test_component_structure.py
@@ -1,6 +1,6 @@
 import pytest
 
-from recsa import ComponentStructure, LocalAuxEdge, RecsaValueError
+from recsa import AuxEdge, ComponentStructure, RecsaValueError
 
 
 @pytest.fixture
@@ -9,7 +9,7 @@ def comp() -> ComponentStructure:
 
 @pytest.fixture
 def comp_with_aux_edges() -> ComponentStructure:
-    return ComponentStructure('M', {'a', 'b'}, {LocalAuxEdge('a', 'b', 'cis')})
+    return ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
 
 
 def test_init_with_valid_args(comp) -> None:
@@ -20,24 +20,24 @@ def test_init_with_valid_args(comp) -> None:
 def test_init_with_valid_args_with_single_aux_edge(comp_with_aux_edges) -> None:
     assert comp_with_aux_edges.component_kind == 'M'
     assert set(comp_with_aux_edges.binding_sites) == {'a', 'b'}
-    assert comp_with_aux_edges.aux_edges == {LocalAuxEdge('a', 'b', 'cis')}
+    assert comp_with_aux_edges.aux_edges == {AuxEdge('a', 'b', 'cis')}
 
 
 def test_init_with_valid_args_with_multiple_aux_edges() -> None:
     component = ComponentStructure('M', {'a', 'b', 'c'}, {
-        LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('a', 'c', 'cis'), 
-        LocalAuxEdge('b', 'c', 'trans')})
+        AuxEdge('a', 'b', 'cis'), AuxEdge('a', 'c', 'cis'), 
+        AuxEdge('b', 'c', 'trans')})
     
     assert component.component_kind == 'M'
     assert set(component.binding_sites) == {'a', 'b', 'c'}
     assert component.aux_edges == {
-        LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('a', 'c', 'cis'), 
-        LocalAuxEdge('b', 'c', 'trans')}
+        AuxEdge('a', 'b', 'cis'), AuxEdge('a', 'c', 'cis'), 
+        AuxEdge('b', 'c', 'trans')}
 
 
 def test_init_with_invalid_aux_edge_whose_binding_sites_not_in_binding_sites() -> None:
     with pytest.raises(RecsaValueError):
-        ComponentStructure('M', {'a', 'b'}, {LocalAuxEdge('a', 'c', 'cis')})
+        ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'c', 'cis')})
 
 
 def test_init_with_empty_binding_sites() -> None:
@@ -55,8 +55,8 @@ def test_init_with_empty_aux_edges() -> None:
 def test_eq() -> None:
     component1 = ComponentStructure('M', {'a', 'b'})
     component2 = ComponentStructure('M', {'a', 'b'})
-    component3 = ComponentStructure('M', {'a', 'b'}, {LocalAuxEdge('a', 'b', 'cis')})
-    component4 = ComponentStructure('M', {'a', 'b'}, {LocalAuxEdge('a', 'b', 'trans')})
+    component3 = ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+    component4 = ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'b', 'trans')})
 
     assert component1 == component2
     assert component1 != component3

--- a/recsa/classes/tests/test_assembly.py
+++ b/recsa/classes/tests/test_assembly.py
@@ -1,6 +1,6 @@
 import pytest
 
-from recsa import Assembly, ComponentStructure, LocalAuxEdge
+from recsa import Assembly, AuxEdge, ComponentStructure
 
 
 @pytest.fixture
@@ -13,8 +13,8 @@ def M_WITH_AUX_EDGES() -> ComponentStructure:
     return ComponentStructure(
         'M', {'a', 'b', 'c', 'd'}, 
         {
-            LocalAuxEdge('a', 'b', 'cis'), LocalAuxEdge('b', 'c', 'cis'),
-            LocalAuxEdge('c', 'd', 'cis'), LocalAuxEdge('d', 'a', 'cis')
+            AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
+            AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')
         })
 
 

--- a/recsa/classes/tests/test_aux_edge.py
+++ b/recsa/classes/tests/test_aux_edge.py
@@ -1,11 +1,11 @@
 import pytest
 
 import recsa as rx
-from recsa import LocalAuxEdge
+from recsa import AuxEdge
 
 
 def test_LocalAuxEdge_initialization():
-    edge = LocalAuxEdge('site1', 'site2', 'cis')
+    edge = AuxEdge('site1', 'site2', 'cis')
     assert edge.local_bindsite1 == 'site1'
     assert edge.local_bindsite2 == 'site2'
     assert edge.aux_kind == 'cis'
@@ -13,29 +13,29 @@ def test_LocalAuxEdge_initialization():
 
 def test_LocalAuxEdge_same_binding_sites():
     with pytest.raises(rx.RecsaValueError):
-        LocalAuxEdge('site1', 'site1', 'cis')
+        AuxEdge('site1', 'site1', 'cis')
 
 
 def test_LocalAuxEdge_equality():
-    edge1 = LocalAuxEdge('site1', 'site2', 'cis')
-    edge2 = LocalAuxEdge('site2', 'site1', 'cis')
+    edge1 = AuxEdge('site1', 'site2', 'cis')
+    edge2 = AuxEdge('site2', 'site1', 'cis')
     assert edge1 == edge2
 
 
 def test_LocalAuxEdge_inequality():
-    edge1 = LocalAuxEdge('site1', 'site2', 'cis')
-    edge2 = LocalAuxEdge('site1', 'site3', 'cis')
+    edge1 = AuxEdge('site1', 'site2', 'cis')
+    edge2 = AuxEdge('site1', 'site3', 'cis')
     assert edge1 != edge2
 
 
 def test_LocalAuxEdge_hash():
-    edge1 = LocalAuxEdge('site1', 'site2', 'cis')
-    edge2 = LocalAuxEdge('site2', 'site1', 'cis')
+    edge1 = AuxEdge('site1', 'site2', 'cis')
+    edge2 = AuxEdge('site2', 'site1', 'cis')
     assert hash(edge1) == hash(edge2)
 
 
 def test_LocalAuxEdge_repr():
-    edge = LocalAuxEdge('site1', 'site2', 'cis')
+    edge = AuxEdge('site1', 'site2', 'cis')
     assert repr(edge) == "LocalAuxEdge('site1', 'site2', 'cis')"
 
 

--- a/recsa/loading/component_structures.py
+++ b/recsa/loading/component_structures.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import yaml
 from pydantic.dataclasses import dataclass
 
-from recsa import ComponentStructure, LocalAuxEdge
+from recsa import AuxEdge, ComponentStructure
 
 __all__ = ['load_component_structures']
 
@@ -60,7 +60,7 @@ def create_component_structures_from_data(
                 for aux_edge in component_structure.aux_edges:
                     bindsite1, bindsite2 = aux_edge.bindsites
                     kind = aux_edge.kind
-                    aux_edges.add(LocalAuxEdge(bindsite1, bindsite2, kind))
+                    aux_edges.add(AuxEdge(bindsite1, bindsite2, kind))
         component_structures[component_structure.id] = ComponentStructure(
             component_structure.id, bindsites, aux_edges)
     return component_structures

--- a/recsa/loading/structure_data.py
+++ b/recsa/loading/structure_data.py
@@ -6,7 +6,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from recsa import ComponentStructure, LocalAuxEdge
+from recsa import AuxEdge, ComponentStructure
 
 __all__ = ['load_structure_data']
 
@@ -78,7 +78,7 @@ def convert_data_to_args(data: StructureData) -> Args:
     component_structures = {
         comp_kind.id: ComponentStructure(
             comp_kind.id, set(comp_kind.bindsites),
-            {LocalAuxEdge(edge.bindsites[0], edge.bindsites[1], edge.kind)
+            {AuxEdge(edge.bindsites[0], edge.bindsites[1], edge.kind)
              for edge in comp_kind.aux_edges or []})
         for comp_kind in data.component_structures
     }


### PR DESCRIPTION
This pull request primarily focuses on renaming the `LocalAuxEdge` class to `AuxEdge` across various files to improve consistency and clarity. The changes span multiple test files and core class files.

### Class Renaming:

* [`recsa/classes/aux_edge.py`](diffhunk://#diff-132570f2f242e928adc29ca143e6a26a3366f63df8141ac7b46d27f1b1fe605cL9-R12): Renamed class `LocalAuxEdge` to `AuxEdge` and updated all references within the file. [[1]](diffhunk://#diff-132570f2f242e928adc29ca143e6a26a3366f63df8141ac7b46d27f1b1fe605cL9-R12) [[2]](diffhunk://#diff-132570f2f242e928adc29ca143e6a26a3366f63df8141ac7b46d27f1b1fe605cL70-R70)

### Test Files Updates:

* [`recsa/algorithms/isomorphism/tests/test_isomorphism_check.py`](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L5-R5): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L5-R5) [[2]](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L22-R23)
* [`recsa/algorithms/isomorphism/tests/test_iteration.py`](diffhunk://#diff-c93a2df085b60bb5fa45b601a15a1b5184f3bcd477d2b283382f438a81e4acaeL3-R3): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-c93a2df085b60bb5fa45b601a15a1b5184f3bcd477d2b283382f438a81e4acaeL3-R3) [[2]](diffhunk://#diff-c93a2df085b60bb5fa45b601a15a1b5184f3bcd477d2b283382f438a81e4acaeL13-R14)
* [`recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py`](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L5-R5): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L5-R5) [[2]](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L23-R24)
* [`recsa/algorithms/tests/test_aux_edge_existence.py`](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L3-R3): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L3-R3) [[2]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L13-R14) [[3]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L37-R38)
* [`recsa/assembly_drawing/tests/test_drawing_2d.py`](diffhunk://#diff-62bc0c8495907d1dd84181d78c2ae7a454cdb36ae3fed24fd95690e14e6f068bL4-R4): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-62bc0c8495907d1dd84181d78c2ae7a454cdb36ae3fed24fd95690e14e6f068bL4-R4) [[2]](diffhunk://#diff-62bc0c8495907d1dd84181d78c2ae7a454cdb36ae3fed24fd95690e14e6f068bL16-R17)
* [`recsa/assembly_drawing/tests/test_drawing_3d.py`](diffhunk://#diff-dbcee1183f535ee3c097e96331eba8ff78b6ce450ee042cda2e3e78f00763054L4-R4): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-dbcee1183f535ee3c097e96331eba8ff78b6ce450ee042cda2e3e78f00763054L4-R4) [[2]](diffhunk://#diff-dbcee1183f535ee3c097e96331eba8ff78b6ce450ee042cda2e3e78f00763054L16-R17)
* [`recsa/classes/tests/test_assembly.py`](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bL3-R3): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bL3-R3) [[2]](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bL16-R17)
* [`recsa/classes/tests/test_aux_edge.py`](diffhunk://#diff-b238afb34fb3c655cda3463ff52ea139ebff7cccad3071415e5cdf57913a003aL4-R38): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`.

### Core Class Files Updates:

* [`recsa/classes/__init__.py`](diffhunk://#diff-e49c189f09b4c2e850a4ec1f2399e71ea487f6f6c41ab13a197aa0c104346a7cL4-R4): Updated import from `LocalAuxEdge` to `AuxEdge`.
* [`recsa/classes/assembly.py`](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L15-R15): Updated import from `LocalAuxEdge` to `AuxEdge`.
* [`recsa/classes/component_structure/bindsite_existence_check.py`](diffhunk://#diff-d0ba3c74a5ab59bbdd88ee1515801aecff1f90db4a5302f539e75e9c0f8b3bfeL3-R9): Updated import and function parameter from `LocalAuxEdge` to `AuxEdge`.
* [`recsa/classes/component_structure/component_structure.py`](diffhunk://#diff-25dfe60e3a589174ebe5c6803e5c26e3d063318c42d8a744166e64f802ff14c0L9-R9): Updated import, class properties, and methods from `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-25dfe60e3a589174ebe5c6803e5c26e3d063318c42d8a744166e64f802ff14c0L9-R9) [[2]](diffhunk://#diff-25dfe60e3a589174ebe5c6803e5c26e3d063318c42d8a744166e64f802ff14c0L23-R23) [[3]](diffhunk://#diff-25dfe60e3a589174ebe5c6803e5c26e3d063318c42d8a744166e64f802ff14c0L90-R90) [[4]](diffhunk://#diff-25dfe60e3a589174ebe5c6803e5c26e3d063318c42d8a744166e64f802ff14c0L141-R141) [[5]](diffhunk://#diff-25dfe60e3a589174ebe5c6803e5c26e3d063318c42d8a744166e64f802ff14c0L153-R167)
* [`recsa/classes/component_structure/tests/test_component_structure.py`](diffhunk://#diff-fb19799b9ff09746784043dad9c0f5d050fdf52a76179c3b2ad542fe2a0dcc00L3-R3): Updated imports and instances of `LocalAuxEdge` to `AuxEdge`. [[1]](diffhunk://#diff-fb19799b9ff09746784043dad9c0f5d050fdf52a76179c3b2ad542fe2a0dcc00L3-R3) [[2]](diffhunk://#diff-fb19799b9ff09746784043dad9c0f5d050fdf52a76179c3b2ad542fe2a0dcc00L12-R12) [[3]](diffhunk://#diff-fb19799b9ff09746784043dad9c0f5d050fdf52a76179c3b2ad542fe2a0dcc00L23-R40) [[4]](diffhunk://#diff-fb19799b9ff09746784043dad9c0f5d050fdf52a76179c3b2ad542fe2a0dcc00L58-R59)