### PR TITLE
Refactor class name ComponentStructure to Component

### DIFF
--- a/recsa/algorithms/assembly_equality.py
+++ b/recsa/algorithms/assembly_equality.py
@@ -2,14 +2,14 @@ from collections.abc import Mapping
 
 from networkx.utils import graphs_equal
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 __all__ = ['assemblies_equal']
 
 
 def assemblies_equal(
         assem1: Assembly, assem2: Assembly,
-        component_kinds: Mapping[str, ComponentStructure]
+        component_kinds: Mapping[str, Component]
         ) -> bool:
     """Check if two assemblies are equal.
 

--- a/recsa/algorithms/aux_edge_existence.py
+++ b/recsa/algorithms/aux_edge_existence.py
@@ -1,13 +1,13 @@
 from collections.abc import Mapping
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 __all__ = ['has_aux_edges']
 
 
 def has_aux_edges(
         assem: Assembly,
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> bool:
     """Check if the assembly has auxiliary edges."""
     comps_with_aux_edges = {

--- a/recsa/algorithms/hashing.py
+++ b/recsa/algorithms/hashing.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 
 import networkx as nx
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 from recsa.algorithms.aux_edge_existence import has_aux_edges
 
 __all__ = [
@@ -15,7 +15,7 @@ __all__ = [
 
 def calc_wl_hash_of_assembly(
         assembly: Assembly, 
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> str:
     if has_aux_edges(assembly, component_structures):
         return calc_pure_wl_hash(assembly, component_structures)
@@ -30,7 +30,7 @@ def calc_rough_wl_hash(assembly: Assembly) -> str:
 
 def calc_pure_wl_hash(
         assembly: Assembly, 
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> str:
     g = assembly.g_snapshot(component_structures)
     _add_attr_for_hash(g)

--- a/recsa/algorithms/isomorphic_assembly_search.py
+++ b/recsa/algorithms/isomorphic_assembly_search.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable, Mapping
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 from recsa.algorithms.hashing import calc_wl_hash_of_assembly
 from recsa.algorithms.isomorphism import is_isomorphic
 
@@ -9,7 +9,7 @@ def find_isomorphic_assembly(
         target_assembly: Assembly,
         id_to_assembly: Mapping[str, Assembly],
         hash_to_ids: Mapping[str, Iterable[str]],
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> str | None:
     # TODO: Reduce the number of calls to calc_wl_hash_of_assembly.
     # Maybe we can use the numbers of each component kind in the assembly.

--- a/recsa/algorithms/isomorphism/isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/isomorphism_check.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 from recsa.algorithms.aux_edge_existence import has_aux_edges
 from recsa.algorithms.isomorphism.pure_isomorphism_check import \
     pure_is_isomorphic
@@ -12,7 +12,7 @@ __all__ = ['is_isomorphic']
 
 def is_isomorphic(
         assem1: Assembly, assem2: Assembly,
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> bool:
     """Check if two assemblies are isomorphic."""
     if assem1.component_kinds != assem2.component_kinds:

--- a/recsa/algorithms/isomorphism/iteration.py
+++ b/recsa/algorithms/isomorphism/iteration.py
@@ -4,14 +4,14 @@ from networkx.algorithms.isomorphism import (GraphMatcher,
                                              categorical_edge_match,
                                              categorical_node_match)
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 __all__ = ['isomorphisms_iter']
 
 
 def isomorphisms_iter(
         assem1: Assembly, assem2: Assembly,
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> Iterator[dict[str, str]]:
     """Find all isomorphisms between two "g_snapshot" graphs of assemblies.
 

--- a/recsa/algorithms/isomorphism/pure_isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/pure_isomorphism_check.py
@@ -4,14 +4,14 @@ import networkx as nx
 from networkx.algorithms.isomorphism import (categorical_edge_match,
                                              categorical_node_match)
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 __all__ = ['pure_is_isomorphic']
 
 
 def pure_is_isomorphic(
         assem1: Assembly, assem2: Assembly,
-        component_kinds: Mapping[str, ComponentStructure]
+        component_kinds: Mapping[str, Component]
         ) -> bool:
     """Check if two assemblies are isomorphic."""
     node_match = categorical_node_match('component_kind', None)

--- a/recsa/algorithms/isomorphism/tests/test_isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/tests/test_isomorphism_check.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import pytest
 
-from recsa import Assembly, AuxEdge, ComponentStructure, is_isomorphic
+from recsa import Assembly, AuxEdge, Component, is_isomorphic
 
 
 @pytest.fixture
@@ -15,14 +15,14 @@ def assem_without_bonds() -> Assembly:
 
 
 @pytest.fixture
-def component_structures() -> dict[str, ComponentStructure]:
-    M_COMP = ComponentStructure(
+def component_structures() -> dict[str, Component]:
+    M_COMP = Component(
         'M', {'a', 'b', 'c', 'd'},
         {
             AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis'),})
-    L_COMP = ComponentStructure('L', {'a', 'b'})
-    X_COMP = ComponentStructure('X', {'a'})
+    L_COMP = Component('L', {'a', 'b'})
+    X_COMP = Component('X', {'a'})
     return {'M': M_COMP, 'L': L_COMP, 'X': X_COMP}
 
 
@@ -45,21 +45,21 @@ def assem2(assem_without_bonds: Assembly) -> Assembly:
 
 
 def test_is_isomorphic_with_isomorphic_assemblies(
-        assem1: Assembly, component_structures: dict[str, ComponentStructure]
+        assem1: Assembly, component_structures: dict[str, Component]
         ) -> None:
     assem3 = deepcopy(assem1)
     assert is_isomorphic(assem1, assem3, component_structures)
 
 
 def test_is_isomorphic_with_clearly_non_isomorphic_assemblies(
-        assem1: Assembly, component_structures: dict[str, ComponentStructure]):
+        assem1: Assembly, component_structures: dict[str, Component]):
     assem2 = deepcopy(assem1)
     assem2.remove_bond('M1.a', 'L1.a')
     assert not is_isomorphic(assem1, assem2, component_structures)
     
 
 def test_is_isomorphic_with_relabelled_assemblies(
-        assem1: Assembly, component_structures: dict[str, ComponentStructure]
+        assem1: Assembly, component_structures: dict[str, Component]
         ) -> None:
     # Should be isomorphic
     assem2 = deepcopy(assem1)
@@ -69,7 +69,7 @@ def test_is_isomorphic_with_relabelled_assemblies(
 
 def test_is_isomorphic_with_stereo_isomers(
         assem1: Assembly, assem2: Assembly, 
-        component_structures: dict[str, ComponentStructure]
+        component_structures: dict[str, Component]
         ) -> None:
     # Should not be isomorphic, though roughly isomorphic
     assert not is_isomorphic(assem1, assem2, component_structures)

--- a/recsa/algorithms/isomorphism/tests/test_iteration.py
+++ b/recsa/algorithms/isomorphism/tests/test_iteration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from recsa import Assembly, AuxEdge, ComponentStructure, isomorphisms_iter
+from recsa import Assembly, AuxEdge, Component, isomorphisms_iter
 
 
 def test_isomorphisms_iter():
@@ -8,12 +8,12 @@ def test_isomorphisms_iter():
         {'M1': 'M', 'L1': 'L', 'L2': 'L', 'X1': 'X', 'X2': 'X'},
         [('M1.a', 'L1.a'), ('M1.b', 'L2.a'), ('M1.c', 'X1.a'), ('M1.d', 'X2.a')])
     COMPONENT_STRUCTURES = {
-        'M': ComponentStructure(
+        'M': Component(
             'M', {'a', 'b', 'c', 'd'},
             {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
              AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'L': ComponentStructure('L', {'a'}),
-        'X': ComponentStructure('X', {'a'})}
+        'L': Component('L', {'a'}),
+        'X': Component('X', {'a'})}
     
     isomorphisms = list(isomorphisms_iter(ML2X2_CIS, ML2X2_CIS, COMPONENT_STRUCTURES))
 

--- a/recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import pytest
 
-from recsa import Assembly, AuxEdge, ComponentStructure
+from recsa import Assembly, AuxEdge, Component
 from recsa.algorithms.isomorphism import pure_is_isomorphic
 
 
@@ -16,14 +16,14 @@ def assem_without_bonds() -> Assembly:
 
 
 @pytest.fixture
-def component_structures() -> dict[str, ComponentStructure]:
-    M_COMP = ComponentStructure(
+def component_structures() -> dict[str, Component]:
+    M_COMP = Component(
         'M', {'a', 'b', 'c', 'd'},
         {
             AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis'),})
-    L_COMP = ComponentStructure('L', {'a', 'b'})
-    X_COMP = ComponentStructure('X', {'a'})
+    L_COMP = Component('L', {'a', 'b'})
+    X_COMP = Component('X', {'a'})
     return {'M': M_COMP, 'L': L_COMP, 'X': X_COMP}
 
 
@@ -46,21 +46,21 @@ def assem2(assem_without_bonds: Assembly) -> Assembly:
 
 
 def test_pure_is_isomorphic_with_isomorphic_assemblies(
-        assem1: Assembly, component_structures: dict[str, ComponentStructure]
+        assem1: Assembly, component_structures: dict[str, Component]
         ) -> None:
     assem3 = deepcopy(assem1)
     assert pure_is_isomorphic(assem1, assem3, component_structures)
 
 
 def test_pure_is_isomorphic_with_clearly_non_isomorphic_assemblies(
-        assem1: Assembly, component_structures: dict[str, ComponentStructure]):
+        assem1: Assembly, component_structures: dict[str, Component]):
     assem2 = deepcopy(assem1)
     assem2.remove_bond('M1.a', 'L1.a')
     assert not pure_is_isomorphic(assem1, assem2, component_structures)
     
 
 def test_pure_is_isomorphic_with_relabelled_assemblies(
-        assem1: Assembly, component_structures: dict[str, ComponentStructure]
+        assem1: Assembly, component_structures: dict[str, Component]
         ) -> None:
     # Should be isomorphic
     assem2 = deepcopy(assem1)
@@ -70,7 +70,7 @@ def test_pure_is_isomorphic_with_relabelled_assemblies(
 
 def test_pure_is_isomorphic_with_stereo_isomers(
         assem1: Assembly, assem2: Assembly, 
-        component_structures: dict[str, ComponentStructure]
+        component_structures: dict[str, Component]
         ) -> None:
     # Should not be isomorphic, though roughly isomorphic
     assert not pure_is_isomorphic(assem1, assem2, component_structures)

--- a/recsa/algorithms/ligand_exchange/tests/test_inter.py
+++ b/recsa/algorithms/ligand_exchange/tests/test_inter.py
@@ -1,7 +1,6 @@
 import pytest
 
-from recsa import (Assembly, ComponentStructure, assemblies_equal,
-                   perform_inter_exchange)
+from recsa import Assembly, Component, assemblies_equal, perform_inter_exchange
 
 
 def test_inter_exchange() -> None:
@@ -22,9 +21,9 @@ def test_inter_exchange() -> None:
     X = X.rename_component_ids({'X1': 'init_X1'})
     
     COMPONENT_KINDS = {
-        'M': ComponentStructure('M', {'a', 'b'}),
-        'L': ComponentStructure('L', {'a'}),
-        'X': ComponentStructure('X', {'a'})}
+        'M': Component('M', {'a', 'b'}),
+        'L': Component('L', {'a'}),
+        'X': Component('X', {'a'})}
     
     product, leaving = perform_inter_exchange(
         MX2, L, 'M1.a', 'X1.a', 'L1.a')

--- a/recsa/algorithms/ligand_exchange/tests/test_intra.py
+++ b/recsa/algorithms/ligand_exchange/tests/test_intra.py
@@ -1,7 +1,6 @@
 import pytest
 
-from recsa import (Assembly, ComponentStructure, assemblies_equal,
-                   perform_intra_exchange)
+from recsa import Assembly, Component, assemblies_equal, perform_intra_exchange
 
 
 def test_intra_exchange() -> None:
@@ -17,9 +16,9 @@ def test_intra_exchange() -> None:
     X = Assembly({'X1': 'X'}, [])
 
     COMPONENT_KINDS = {
-        'M': ComponentStructure('M', {'a', 'b'}),
-        'L': ComponentStructure('L', {'a', 'b'}),
-        'X': ComponentStructure('X', {'a'})}
+        'M': Component('M', {'a', 'b'}),
+        'L': Component('L', {'a', 'b'}),
+        'X': Component('X', {'a'})}
     
     product, leaving = perform_intra_exchange(
         MLX, 'M1.a', 'X1.a', 'L1.b')

--- a/recsa/algorithms/tests/test_aux_edge_existence.py
+++ b/recsa/algorithms/tests/test_aux_edge_existence.py
@@ -1,6 +1,6 @@
 import pytest
 
-from recsa import Assembly, AuxEdge, ComponentStructure, has_aux_edges
+from recsa import Assembly, AuxEdge, Component, has_aux_edges
 
 
 def test_has_aux_edges_true():
@@ -8,11 +8,11 @@ def test_has_aux_edges_true():
         {'M1': 'M', 'X1': 'X', 'X2': 'X', 'X3': 'X', 'X4': 'X'},
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'X4.a')])
     COMPONENT_STRUCTURES = {
-        'M': ComponentStructure(
+        'M': Component(
             'M', {'a', 'b', 'c', 'd'}, 
             {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
              AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'X': ComponentStructure('X', {'a'})}
+        'X': Component('X', {'a'})}
     assert has_aux_edges(MX4, COMPONENT_STRUCTURES)
 
 
@@ -21,8 +21,8 @@ def test_has_aux_edges_false():
         {'M1': 'M', 'X1': 'X', 'X2': 'X', 'X3': 'X', 'X4': 'X'},
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'X4.a')])
     COMPONENT_STRUCTURES = {
-        'M': ComponentStructure('M', {'a', 'b', 'c', 'd'}),  # No aux edges
-        'X': ComponentStructure('X', {'a'})}
+        'M': Component('M', {'a', 'b', 'c', 'd'}),  # No aux edges
+        'X': Component('X', {'a'})}
     assert not has_aux_edges(MX4, COMPONENT_STRUCTURES)
 
 
@@ -31,12 +31,12 @@ def test_has_aux_edges_false2():
         {'M1': 'M', 'X1': 'X', 'X2': 'X', 'X3': 'X', 'X4': 'X'},
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'X4.a')])
     COMPONENT_STRUCTURES = {
-        'M': ComponentStructure('M', {'a', 'b', 'c', 'd'}),  # No aux edges
-        'L': ComponentStructure(
+        'M': Component('M', {'a', 'b', 'c', 'd'}),  # No aux edges
+        'L': Component(
             'L', {'a', 'b', 'c', 'd'},
             {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
              AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),  # Aux edges but not in assembly
-        'X': ComponentStructure('X', {'a'})}
+        'X': Component('X', {'a'})}
     assert not has_aux_edges(MX4, COMPONENT_STRUCTURES)
 
 

--- a/recsa/assembly_drawing/drawing_2d.py
+++ b/recsa/assembly_drawing/drawing_2d.py
@@ -4,7 +4,7 @@ from typing import Literal
 import matplotlib.pyplot as plt
 import networkx as nx
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 from .lib import make_complete_color_map
 
@@ -13,7 +13,7 @@ __all__ = ['draw_2d']
 
 def draw_2d(
         assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         positions: Mapping[str, tuple[float, float]],
         *,
         show: bool = True,

--- a/recsa/assembly_drawing/drawing_3d.py
+++ b/recsa/assembly_drawing/drawing_3d.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 from .lib import make_complete_color_map
 
@@ -14,7 +14,7 @@ __all__ = ['draw_3d']
 
 def draw_3d(
         assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         positions: Mapping[str, tuple[float, float, float]],
         *,
         show: bool = True,

--- a/recsa/assembly_drawing/positioning.py
+++ b/recsa/assembly_drawing/positioning.py
@@ -3,7 +3,7 @@ from typing import Literal, TypeAlias, overload
 
 import networkx as nx
 
-from recsa import Assembly, ComponentStructure, RecsaValueError
+from recsa import Assembly, Component, RecsaValueError
 
 LAYOUT_NAME_TO_FUNC = {
     'spring': nx.spring_layout,
@@ -19,7 +19,7 @@ PosDict3D: TypeAlias = dict[str, tuple[float, float, float]]
 @overload
 def calc_positions(
         assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         *,
         dimensions: Literal['2d'] = '2d',
         layout_name: Literal['spring'] = 'spring', 
@@ -31,7 +31,7 @@ def calc_positions(
 @overload
 def calc_positions(
         assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         *,
         dimensions: Literal['3d'],
         layout_name: Literal['spring'] = 'spring', 
@@ -42,7 +42,7 @@ def calc_positions(
     ...
 def calc_positions(
         assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         *,
         dimensions: Literal['2d', '3d'] = '2d',
         layout_name: Literal['spring'] = 'spring', 

--- a/recsa/assembly_drawing/tests/test_drawing_2d.py
+++ b/recsa/assembly_drawing/tests/test_drawing_2d.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import pytest
 
-from recsa import Assembly, AuxEdge, ComponentStructure, draw_2d
+from recsa import Assembly, AuxEdge, Component, draw_2d
 
 
 @pytest.mark.skip(reason='This is a visual test.')
@@ -11,12 +11,12 @@ def test_draw_2d():
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'L1.a')],
     )
     COMPONENT_STRUCTURES = {
-        'M': ComponentStructure(
+        'M': Component(
             'M', {'a', 'b', 'c', 'd'}, {
                 AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
                 AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'L': ComponentStructure('L', {'a', 'b'}),
-        'X': ComponentStructure('X', {'a'}),
+        'L': Component('L', {'a', 'b'}),
+        'X': Component('X', {'a'}),
     }
 
     positions = nx.spring_layout(MLX3.g_snapshot(COMPONENT_STRUCTURES))

--- a/recsa/assembly_drawing/tests/test_drawing_3d.py
+++ b/recsa/assembly_drawing/tests/test_drawing_3d.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import pytest
 
-from recsa import Assembly, AuxEdge, ComponentStructure, draw_3d
+from recsa import Assembly, AuxEdge, Component, draw_3d
 
 
 @pytest.mark.skip(reason='This is a visual test.')
@@ -11,12 +11,12 @@ def test_draw_3d():
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'L1.a')],
     )
     COMPONENT_STRUCTURES = {
-        'M': ComponentStructure(
+        'M': Component(
             'M', {'a', 'b', 'c', 'd'}, {
                 AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
                 AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'L': ComponentStructure('L', {'a', 'b'}),
-        'X': ComponentStructure('X', {'a'}),
+        'L': Component('L', {'a', 'b'}),
+        'X': Component('X', {'a'}),
     }
 
     positions = nx.spring_layout(

--- a/recsa/bindsite_capping/multi_bindsites.py
+++ b/recsa/bindsite_capping/multi_bindsites.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from itertools import count
 from typing import Literal, overload
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 from .single_bindsite import cap_single_bindsite
 
@@ -12,7 +12,7 @@ __all__ = ['cap_bindsites']
 @overload
 def cap_bindsites(
         assembly: Assembly, 
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         component_kind_to_be_capped: str,
         cap_component_kind: str, cap_bindsite: str,
         copy: Literal[True] = True
@@ -20,14 +20,14 @@ def cap_bindsites(
 @overload
 def cap_bindsites(
         assembly: Assembly, 
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         component_kind_to_be_capped: str,
         cap_component_kind: str, cap_bindsite: str,
         copy: Literal[False]
         ) -> None: ...
 def cap_bindsites(
         assembly: Assembly, 
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         component_kind_to_be_capped: str,
         cap_component_kind: str, cap_bindsite: str,
         copy: bool = True

--- a/recsa/classes/__init__.py
+++ b/recsa/classes/__init__.py
@@ -2,7 +2,7 @@
 
 from .assembly import Assembly
 from .aux_edge import AuxEdge
-from .component_structure import ComponentStructure
+from .component_structure import Component
 from .mle import MleBindsite
 from .mle import MleKind
 from .reaction import InterReaction

--- a/recsa/classes/assembly.py
+++ b/recsa/classes/assembly.py
@@ -14,7 +14,7 @@ from recsa import RecsaValueError
 
 from .aux_edge import AuxEdge
 from .bindsite_id_converter import BindsiteIdConverter
-from .component_structure import ComponentStructure
+from .component_structure import Component
 
 __all__ = ['Assembly', 'assembly_to_graph', 'assembly_to_rough_graph', 'find_free_bindsites']
 
@@ -123,7 +123,7 @@ class Assembly:
         return MappingProxyType(self.__bindsite_to_connected.copy())
     
     def g_snapshot(
-            self, component_structures: Mapping[str, ComponentStructure]
+            self, component_structures: Mapping[str, Component]
             ) -> nx.Graph:
         """Returns a snapshot of the assembly graph.
         
@@ -321,7 +321,7 @@ class Assembly:
             yield id_converter.local_to_global(comp_id, 'core')
     
     def get_all_bindsites(
-            self, component_structures: Mapping[str, ComponentStructure]
+            self, component_structures: Mapping[str, Component]
             ) -> set[str]:
         """Get all the binding sites in the assembly."""
         # TODO: Consider yielding the binding sites instead of returning a set.
@@ -334,7 +334,7 @@ class Assembly:
         return all_bindsites
 
     def iter_aux_edges(
-            self, component_structures: Mapping[str, ComponentStructure]
+            self, component_structures: Mapping[str, Component]
             ) -> Iterator[AbsAuxEdge]:
         id_converter = BindsiteIdConverter()
         for comp_id, comp_kind in self.component_id_to_kind.items():
@@ -349,7 +349,7 @@ class Assembly:
 
     def get_bindsites_of_component(
             self, component_id: str, 
-            component_structures: Mapping[str, ComponentStructure]
+            component_structures: Mapping[str, Component]
             ) -> set[str]:
         """Get the binding sites of the component."""
         id_converter = BindsiteIdConverter()
@@ -361,7 +361,7 @@ class Assembly:
     
     def get_all_bindsites_of_kind(
             self, component_kind: str,
-            component_structures: Mapping[str, ComponentStructure],
+            component_structures: Mapping[str, Component],
             ) -> Iterator[str]:
         for comp_id, comp in self.component_id_to_kind.items():
             if comp == component_kind:
@@ -369,7 +369,7 @@ class Assembly:
                     comp_id, component_structures)
 
     def find_free_bindsites(
-            self, component_structures: Mapping[str, ComponentStructure]
+            self, component_structures: Mapping[str, Component]
             ) -> set[str]:
         """Find free bindsites."""
         id_converter = BindsiteIdConverter()
@@ -387,7 +387,7 @@ class Assembly:
     # ============================================================
 
     def _to_graph(
-            self, component_kinds: Mapping[str, ComponentStructure]
+            self, component_kinds: Mapping[str, Component]
             ) -> nx.Graph:
         return assembly_to_graph(self, component_kinds)
 
@@ -413,7 +413,7 @@ class Assembly:
 
 def assembly_to_graph(
         assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> nx.Graph:
     G = nx.Graph()
     for comp_id, comp_kind in assembly.component_id_to_kind.items():
@@ -427,7 +427,7 @@ def assembly_to_graph(
 def add_component_to_graph(
         g: nx.Graph,
         component_id: str, component_kind: str,
-        component_structure: ComponentStructure,
+        component_structure: Component,
         ) -> None:
     # Add the core node
     id_converter = BindsiteIdConverter()

--- a/recsa/classes/component_structure/component_structure.py
+++ b/recsa/classes/component_structure/component_structure.py
@@ -11,10 +11,10 @@ from ..validations import (validate_name_of_binding_site,
                            validate_name_of_component_kind)
 from .bindsite_existence_check import check_bindsites_of_aux_edges_exists
 
-__all__ = ['ComponentStructure']
+__all__ = ['Component']
 
 
-class ComponentStructure:
+class Component:
     """A component of an assembly."""
 
     def __init__(
@@ -50,7 +50,7 @@ class ComponentStructure:
         self.__g_cache = None
     
     def __eq__(self, value: object) -> bool:
-        if not isinstance(value, ComponentStructure):
+        if not isinstance(value, Component):
             return False
         return (
             self.__component_kind == value.__component_kind and
@@ -64,7 +64,7 @@ class ComponentStructure:
         calling the method."""
         @wraps(func)
         def wrapper(self, *args, **kwargs):
-            assert hasattr(self, '_ComponentStructure__g_cache'), (
+            assert hasattr(self, '_Component__g_cache'), (
                 'The "__g_cache" attribute is not found. '
                 'Please make sure that the "__g_cache" attribute is '
                 'initialized in the __init__ method.')

--- a/recsa/classes/component_structure/tests/test_component_structure.py
+++ b/recsa/classes/component_structure/tests/test_component_structure.py
@@ -1,15 +1,15 @@
 import pytest
 
-from recsa import AuxEdge, ComponentStructure, RecsaValueError
+from recsa import AuxEdge, Component, RecsaValueError
 
 
 @pytest.fixture
-def comp() -> ComponentStructure:
-    return ComponentStructure('M', {'a', 'b'})
+def comp() -> Component:
+    return Component('M', {'a', 'b'})
 
 @pytest.fixture
-def comp_with_aux_edges() -> ComponentStructure:
-    return ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+def comp_with_aux_edges() -> Component:
+    return Component('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
 
 
 def test_init_with_valid_args(comp) -> None:
@@ -24,7 +24,7 @@ def test_init_with_valid_args_with_single_aux_edge(comp_with_aux_edges) -> None:
 
 
 def test_init_with_valid_args_with_multiple_aux_edges() -> None:
-    component = ComponentStructure('M', {'a', 'b', 'c'}, {
+    component = Component('M', {'a', 'b', 'c'}, {
         AuxEdge('a', 'b', 'cis'), AuxEdge('a', 'c', 'cis'), 
         AuxEdge('b', 'c', 'trans')})
     
@@ -37,26 +37,26 @@ def test_init_with_valid_args_with_multiple_aux_edges() -> None:
 
 def test_init_with_invalid_aux_edge_whose_binding_sites_not_in_binding_sites() -> None:
     with pytest.raises(RecsaValueError):
-        ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'c', 'cis')})
+        Component('M', {'a', 'b'}, {AuxEdge('a', 'c', 'cis')})
 
 
 def test_init_with_empty_binding_sites() -> None:
     # Empty binding sites is allowed.
-    component = ComponentStructure('M', set())
+    component = Component('M', set())
     assert component.binding_sites == set()
 
 
 def test_init_with_empty_aux_edges() -> None:
     # Empty aux_edges is allowed.
-    component = ComponentStructure('M', {'a', 'b'}, set())
+    component = Component('M', {'a', 'b'}, set())
     assert component.aux_edges == set()
 
 
 def test_eq() -> None:
-    component1 = ComponentStructure('M', {'a', 'b'})
-    component2 = ComponentStructure('M', {'a', 'b'})
-    component3 = ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
-    component4 = ComponentStructure('M', {'a', 'b'}, {AuxEdge('a', 'b', 'trans')})
+    component1 = Component('M', {'a', 'b'})
+    component2 = Component('M', {'a', 'b'})
+    component3 = Component('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+    component4 = Component('M', {'a', 'b'}, {AuxEdge('a', 'b', 'trans')})
 
     assert component1 == component2
     assert component1 != component3
@@ -67,8 +67,8 @@ def test_clear_g_cache(comp) -> None:
     comp._Component__g_cache = 1
     assert comp._Component__g_cache == 1
 
-    comp._ComponentStructure__add_binding_site('c')
-    assert comp._ComponentStructure__g_cache is None
+    comp._Component__add_binding_site('c')
+    assert comp._Component__g_cache is None
 
 
 if __name__ == '__main__':

--- a/recsa/classes/tests/test_assembly.py
+++ b/recsa/classes/tests/test_assembly.py
@@ -1,16 +1,16 @@
 import pytest
 
-from recsa import Assembly, AuxEdge, ComponentStructure
+from recsa import Assembly, AuxEdge, Component
 
 
 @pytest.fixture
-def M_COMP() -> ComponentStructure:
-    return ComponentStructure('M', {'a', 'b', 'c', 'd'})
+def M_COMP() -> Component:
+    return Component('M', {'a', 'b', 'c', 'd'})
 
 
 @pytest.fixture
-def M_WITH_AUX_EDGES() -> ComponentStructure:
-    return ComponentStructure(
+def M_WITH_AUX_EDGES() -> Component:
+    return Component(
         'M', {'a', 'b', 'c', 'd'}, 
         {
             AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
@@ -19,13 +19,13 @@ def M_WITH_AUX_EDGES() -> ComponentStructure:
 
 
 @pytest.fixture
-def L_COMP() -> ComponentStructure:
-    return ComponentStructure('L', {'a', 'b'})
+def L_COMP() -> Component:
+    return Component('L', {'a', 'b'})
 
 
 @pytest.fixture
-def X_COMP() -> ComponentStructure:
-    return ComponentStructure('X', {'a'})
+def X_COMP() -> Component:
+    return Component('X', {'a'})
 
 
 def test_init_with_no_args() -> None:

--- a/recsa/duplicate_exclusion/core.py
+++ b/recsa/duplicate_exclusion/core.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping
 
-from recsa import Assembly, ComponentStructure, calc_wl_hash_of_assembly
+from recsa import Assembly, Component, calc_wl_hash_of_assembly
 
 from .lib.is_new_check import is_new
 
@@ -10,7 +10,7 @@ __all__ = ['find_unique_assemblies']
 
 def find_unique_assemblies(
         assemblies: Iterable[tuple[str, Assembly]],
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> Iterator[tuple[str, Assembly]]:
     """Get unique assemblies.
 

--- a/recsa/duplicate_exclusion/detailed.py
+++ b/recsa/duplicate_exclusion/detailed.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 from .lib import group_assemblies_by_isomorphism
 
@@ -9,7 +9,7 @@ __all__ = ['exclude_remaining_duplicates']
 
 def exclude_remaining_duplicates(
         id_to_assembly: Mapping[str, Assembly],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> tuple[dict[str, Assembly], dict[str, set[str]]]:
     """Exclude remaining duplicates."""
     unique_id_to_ids = group_assemblies_by_isomorphism(id_to_assembly, component_structures)

--- a/recsa/duplicate_exclusion/lib/grouping_by_hash.py
+++ b/recsa/duplicate_exclusion/lib/grouping_by_hash.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
 from collections.abc import Mapping
 
-from recsa import Assembly, ComponentStructure, calc_wl_hash_of_assembly
+from recsa import Assembly, Component, calc_wl_hash_of_assembly
 
 __all__ = ['group_assemblies_by_hash']
 
 def group_assemblies_by_hash(
         id_to_assembly: Mapping[str, Assembly],
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> dict[str, set[str]]:
     # Group by hash
     hash_to_ids = defaultdict(set)

--- a/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
+++ b/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
@@ -3,7 +3,7 @@ from itertools import combinations
 
 from networkx.utils import UnionFind
 
-from recsa import Assembly, ComponentStructure, is_isomorphic
+from recsa import Assembly, Component, is_isomorphic
 
 from .grouping_by_hash import group_assemblies_by_hash
 
@@ -12,7 +12,7 @@ __all__ = ['group_assemblies_by_isomorphism']
 
 def group_assemblies_by_isomorphism(
         id_to_assembly: Mapping[str, Assembly],
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> dict[str, set[str]]:
     """Group duplicates by assembly isomorphism.
 

--- a/recsa/duplicate_exclusion/lib/is_new_check.py
+++ b/recsa/duplicate_exclusion/lib/is_new_check.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 
-from recsa import Assembly, ComponentStructure, is_isomorphic
+from recsa import Assembly, Component, is_isomorphic
 
 __all__ = ['is_new']
 
@@ -9,7 +9,7 @@ def is_new(
         hash_: str,
         assembly: Assembly,
         hash_to_uniques: Mapping[str, list[Assembly]],
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> bool:
     """Check if the assembly is new."""
     if hash_ not in hash_to_uniques:

--- a/recsa/duplicate_exclusion/lib/tests/test_grouping_by_isomorphism.py
+++ b/recsa/duplicate_exclusion/lib/tests/test_grouping_by_isomorphism.py
@@ -1,6 +1,6 @@
 import pytest
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 from recsa.duplicate_exclusion import group_assemblies_by_isomorphism
 
 
@@ -23,9 +23,9 @@ def test_group_assemblies_by_isomorphism():
             []),
     }
     component_structures = {
-        'M': ComponentStructure('M', {'a', 'b'}),
-        'L': ComponentStructure('L', {'a', 'b'}),
-        'X': ComponentStructure('X', {'a'}),
+        'M': Component('M', {'a', 'b'}),
+        'L': Component('L', {'a', 'b'}),
+        'X': Component('X', {'a'}),
     }
 
     grouped_ids = group_assemblies_by_isomorphism(id_to_graph, component_structures)

--- a/recsa/loading/component_structures.py
+++ b/recsa/loading/component_structures.py
@@ -3,14 +3,14 @@ from pathlib import Path
 import yaml
 from pydantic.dataclasses import dataclass
 
-from recsa import AuxEdge, ComponentStructure
+from recsa import AuxEdge, Component
 
 __all__ = ['load_component_structures']
 
 
 def load_component_structures(
         file_path: str | Path
-        ) -> dict[str, ComponentStructure]:
+        ) -> dict[str, Component]:
     """Load ComponentStructure objects from a YAML file."""
     file_path = Path(file_path)
     data = load_yaml(file_path)
@@ -49,7 +49,7 @@ def load_yaml(file_path: str | Path) -> list[ComponentStructureData]:
 
 def create_component_structures_from_data(
         data: list[ComponentStructureData]
-        ) -> dict[str, ComponentStructure]:
+        ) -> dict[str, Component]:
     """Create ComponentStructure objects from a dictionary."""
     component_structures = {}
     for component_structure in data:
@@ -61,6 +61,6 @@ def create_component_structures_from_data(
                     bindsite1, bindsite2 = aux_edge.bindsites
                     kind = aux_edge.kind
                     aux_edges.add(AuxEdge(bindsite1, bindsite2, kind))
-        component_structures[component_structure.id] = ComponentStructure(
+        component_structures[component_structure.id] = Component(
             component_structure.id, bindsites, aux_edges)
     return component_structures

--- a/recsa/loading/structure_data.py
+++ b/recsa/loading/structure_data.py
@@ -6,14 +6,14 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from recsa import AuxEdge, ComponentStructure
+from recsa import AuxEdge, Component
 
 __all__ = ['load_structure_data']
 
 
 @dataclass
 class Args:
-    component_structures: dict[str, ComponentStructure]
+    component_structures: dict[str, Component]
     components: dict[str, str]
     bond_id_to_bindsites: dict[str, frozenset[str]]
 
@@ -76,7 +76,7 @@ def load_yaml(file_path: str | Path) -> StructureData:
 
 def convert_data_to_args(data: StructureData) -> Args:
     component_structures = {
-        comp_kind.id: ComponentStructure(
+        comp_kind.id: Component(
             comp_kind.id, set(comp_kind.bindsites),
             {AuxEdge(edge.bindsites[0], edge.bindsites[1], edge.kind)
              for edge in comp_kind.aux_edges or []})

--- a/recsa/reaction_exploration/core.py
+++ b/recsa/reaction_exploration/core.py
@@ -2,7 +2,7 @@ import itertools
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
 
-from recsa import (Assembly, ComponentStructure, InterReaction, IntraReaction,
+from recsa import (Assembly, Component, InterReaction, IntraReaction,
                    calc_wl_hash_of_assembly)
 from recsa.algorithms.hashing import calc_wl_hash_of_assembly
 
@@ -13,7 +13,7 @@ from .intra import explore_intra_reactions
 def explore_reactions(
         id_to_assembly: Mapping[str, Assembly],
         metal_kind: str, leaving_kind: str, entering_kind: str,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> Iterator[IntraReaction | InterReaction]:
     hash_to_ids = defaultdict(list)
     for assem_id, assembly in id_to_assembly.items():

--- a/recsa/reaction_exploration/inter.py
+++ b/recsa/reaction_exploration/inter.py
@@ -1,7 +1,7 @@
 import itertools
 from collections.abc import Iterable, Iterator, Mapping
 
-from recsa import (Assembly, ComponentStructure, find_isomorphic_assembly,
+from recsa import (Assembly, Component, find_isomorphic_assembly,
                    perform_inter_exchange)
 from recsa.classes.reaction import InterReaction
 
@@ -16,7 +16,7 @@ def explore_inter_reactions(
         metal_kind: str, leaving_kind: str, entering_kind: str,
         id_to_assembly: Mapping[str, Assembly],
         hash_to_ids: Mapping[str, Iterable[str]],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> Iterator[InterReaction]:
     init_assem = id_to_assembly[init_assem_id]
     entering_assem = id_to_assembly[entering_assem_id]

--- a/recsa/reaction_exploration/intra.py
+++ b/recsa/reaction_exploration/intra.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable, Iterator, Mapping
 
-from recsa import (Assembly, ComponentStructure, find_isomorphic_assembly,
+from recsa import (Assembly, Component, find_isomorphic_assembly,
                    perform_intra_exchange)
 from recsa.classes.reaction import IntraReaction
 
@@ -13,7 +13,7 @@ def explore_intra_reactions(
         metal_kind: str, leaving_kind: str, entering_kind: str,
         id_to_assembly: Mapping[str, Assembly],
         hash_to_ids: Mapping[str, Iterable[str]],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> Iterator[IntraReaction]:
     init_assem = id_to_assembly[init_assem_id]
 

--- a/recsa/reaction_exploration/lib/cached_self_isomorphism_iteration.py
+++ b/recsa/reaction_exploration/lib/cached_self_isomorphism_iteration.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 
 from cachetools import cached
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 from recsa.algorithms import isomorphisms_iter
 
 __all__ = ['iter_self_isomorphisms_with_cache']
@@ -11,7 +11,7 @@ __all__ = ['iter_self_isomorphisms_with_cache']
 def _cache_key(
         assembly_id: str,
         assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> str:
     return assembly_id
 
@@ -19,7 +19,7 @@ def _cache_key(
 @cached(cache={}, key=_cache_key)
 def iter_self_isomorphisms_with_cache(
         assembly_id: str, assembly: Assembly,
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> list[dict[str, str]]:
     """Iterate over self-isomorphisms of an assembly.
 

--- a/recsa/reaction_exploration/lib/entering_bindsite_enumeration.py
+++ b/recsa/reaction_exploration/lib/entering_bindsite_enumeration.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from cachetools import cached
 from cachetools.keys import hashkey
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 __all__ = ['enum_valid_entering_bindsites']
 
@@ -12,7 +12,7 @@ def _cache_key2(
         assembly_id: str,
         assembly: Assembly,
         entering_kind: str,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> tuple:
     return hashkey(assembly_id, entering_kind)
 
@@ -22,7 +22,7 @@ def enum_valid_entering_bindsites(
         assembly_id: str,  # only used for caching
         assembly: Assembly,
         entering_kind: str,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> list[str]:
     """Enumerate valid entering bindsites.
 

--- a/recsa/reaction_exploration/lib/ml_pair_enumeration.py
+++ b/recsa/reaction_exploration/lib/ml_pair_enumeration.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from cachetools import cached
 from cachetools.keys import hashkey
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 __all__ = ['enum_valid_ml_pairs']
 
@@ -12,7 +12,7 @@ def _cache_key(
         assembly_id: str,
         assembly: Assembly,
         metal_kind: str, leaving_kind: str,
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> tuple:
     return hashkey(assembly_id, metal_kind, leaving_kind)
 
@@ -22,7 +22,7 @@ def enum_valid_ml_pairs(
         assembly_id: str,  # only used for caching
         assembly: Assembly,
         metal_kind: str, leaving_kind: str,
-        component_structures: Mapping[str, ComponentStructure]
+        component_structures: Mapping[str, Component]
         ) -> list[tuple[str, str]]:
     """Enumerate valid metal-leaving pairs in an assembly.
 

--- a/recsa/reaction_exploration/lib/mle_enumeration_for_intra.py
+++ b/recsa/reaction_exploration/lib/mle_enumeration_for_intra.py
@@ -4,7 +4,7 @@ from itertools import product
 from cachetools import cached
 from cachetools.keys import hashkey
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 
 __all__ = ['enum_valid_mles_for_intra']
 
@@ -13,7 +13,7 @@ def _cache_key(
         assembly_id: str,
         assembly: Assembly,
         metal_kind: str, leaving_kind: str, entering_kind: str,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> tuple:
     return hashkey(assembly_id, metal_kind, leaving_kind, entering_kind)
 
@@ -23,7 +23,7 @@ def enum_valid_mles_for_intra(
         assembly_id: str,  # only used for caching
         assembly: Assembly,
         metal_kind: str, leaving_kind: str, entering_kind: str,
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> list[tuple[str, str, str]]:
     """
     Get all possible metal-leaving-entering (MLE) site trios in an assembly.

--- a/recsa/reaction_exploration/lib/unique_bindsite_or_bindsite_sets.py
+++ b/recsa/reaction_exploration/lib/unique_bindsite_or_bindsite_sets.py
@@ -4,7 +4,7 @@ from typing import overload
 from cachetools import cached
 from cachetools.keys import hashkey
 
-from recsa import Assembly, ComponentStructure
+from recsa import Assembly, Component
 from recsa.utils import group_equivalent_nodes_or_nodesets
 
 from .cached_self_isomorphism_iteration import \
@@ -17,7 +17,7 @@ def _cache_key(
         assembly_id: str,
         assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[str] | Iterable[tuple[str, ...]],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> tuple:
     return hashkey(assembly_id, frozenset(bindsites_or_bindsite_sets))
 
@@ -26,25 +26,25 @@ def _cache_key(
 def compute_unique_bindsites_or_bindsite_sets(
         assembly_id: str, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[str],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> list[tuple[str, int]]: ...
 @overload
 def compute_unique_bindsites_or_bindsite_sets(
         assembly_id: str, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[tuple[str, str]],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> list[tuple[tuple[str, str], int]]: ...
 @overload
 def compute_unique_bindsites_or_bindsite_sets(
         assembly_id: str, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[tuple[str, str, str]],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> list[tuple[tuple[str, str, str], int]]: ...
 @overload
 def compute_unique_bindsites_or_bindsite_sets(
         assembly_id: str, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[tuple[str, ...]],
-        component_structures: Mapping[str, ComponentStructure],
+        component_structures: Mapping[str, Component],
         ) -> list[tuple[tuple[str, ...], int]]: ...
 @cached(cache={}, key=_cache_key)
 def compute_unique_bindsites_or_bindsite_sets(


### PR DESCRIPTION
This pull request involves a significant refactor to replace the `ComponentStructure` class with the `Component` class across various modules in the `recsa` package. The changes span multiple files and functions, ensuring consistency and updating the type annotations accordingly.

### Refactor ComponentStructure to Component

* [`recsa/algorithms/assembly_equality.py`](diffhunk://#diff-11e294a767c7752ad69f7d39af24ebee94184cfc3d018320e865b3a84d285600L5-R12): Updated imports and function parameters to use `Component` instead of `ComponentStructure`.
* [`recsa/algorithms/aux_edge_existence.py`](diffhunk://#diff-2bcc50f7e0d25db8b6ce74326ae1e86899da1cdea52474b2c426810013de6133L3-R10): Replaced `ComponentStructure` with `Component` in imports and function parameters.
* [`recsa/algorithms/hashing.py`](diffhunk://#diff-a057c8a058204234fe7c5b8f881dcf8d4b1f1e5bd43123185ccdb242f28a87ceL5-R5): Changed type annotations and imports to use `Component`. [[1]](diffhunk://#diff-a057c8a058204234fe7c5b8f881dcf8d4b1f1e5bd43123185ccdb242f28a87ceL5-R5) [[2]](diffhunk://#diff-a057c8a058204234fe7c5b8f881dcf8d4b1f1e5bd43123185ccdb242f28a87ceL18-R18) [[3]](diffhunk://#diff-a057c8a058204234fe7c5b8f881dcf8d4b1f1e5bd43123185ccdb242f28a87ceL33-R33)
* [`recsa/algorithms/isomorphic_assembly_search.py`](diffhunk://#diff-5fab26d246ed337281626274b3af269937b3691cd2cc6583f41f47724eaa0131L3-R3): Updated function parameters and imports to use `Component`. [[1]](diffhunk://#diff-5fab26d246ed337281626274b3af269937b3691cd2cc6583f41f47724eaa0131L3-R3) [[2]](diffhunk://#diff-5fab26d246ed337281626274b3af269937b3691cd2cc6583f41f47724eaa0131L12-R12)
* [`recsa/algorithms/isomorphism/isomorphism_check.py`](diffhunk://#diff-b636e6cbd3bc089bb53d83ec83bbe7290a4efafb692c1b613fbdf56dda4ab54bL3-R3): Modified imports and function parameters to use `Component`. [[1]](diffhunk://#diff-b636e6cbd3bc089bb53d83ec83bbe7290a4efafb692c1b613fbdf56dda4ab54bL3-R3) [[2]](diffhunk://#diff-b636e6cbd3bc089bb53d83ec83bbe7290a4efafb692c1b613fbdf56dda4ab54bL15-R15)

### Update Tests for Component Refactor

* [`recsa/algorithms/isomorphism/tests/test_isomorphism_check.py`](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L5-R5): Updated test fixtures and assertions to use `Component`. [[1]](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L5-R5) [[2]](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L18-R25) [[3]](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L48-R62) [[4]](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L72-R72)
* [`recsa/algorithms/isomorphism/tests/test_iteration.py`](diffhunk://#diff-c93a2df085b60bb5fa45b601a15a1b5184f3bcd477d2b283382f438a81e4acaeL3-R16): Replaced `ComponentStructure` with `Component` in test data.
* [`recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py`](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L5-R5): Updated test fixtures and assertions to use `Component`. [[1]](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L5-R5) [[2]](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L19-R26) [[3]](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L49-R63) [[4]](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L73-R73)
* [`recsa/algorithms/ligand_exchange/tests/test_inter.py`](diffhunk://#diff-3573dc145edb5452d3dfd4b5a2d4c0c2efddf38605d2afe354e1251c9dc19442L3-R3): Modified test data to use `Component`. [[1]](diffhunk://#diff-3573dc145edb5452d3dfd4b5a2d4c0c2efddf38605d2afe354e1251c9dc19442L3-R3) [[2]](diffhunk://#diff-3573dc145edb5452d3dfd4b5a2d4c0c2efddf38605d2afe354e1251c9dc19442L25-R26)
* [`recsa/algorithms/ligand_exchange/tests/test_intra.py`](diffhunk://#diff-013b6f764b149e564149609a2cf6ef5df0e4089f6095f29ec33c2be490413648L3-R3): Updated test data to use `Component`. [[1]](diffhunk://#diff-013b6f764b149e564149609a2cf6ef5df0e4089f6095f29ec33c2be490413648L3-R3) [[2]](diffhunk://#diff-013b6f764b149e564149609a2cf6ef5df0e4089f6095f29ec33c2be490413648L20-R21)
* [`recsa/algorithms/tests/test_aux_edge_existence.py`](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L3-R15): Changed test data to use `Component`. [[1]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L3-R15) [[2]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L24-R25) [[3]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L34-R39)

### Update Drawing Functions

* [`recsa/assembly_drawing/drawing_2d.py`](diffhunk://#diff-8ad4ad5c87b1e0f2e302d594a39a7e967822a69d68c3bda2bf7e21e49cdaff38L7-R7): Updated type annotations and imports to use `Component`. [[1]](diffhunk://#diff-8ad4ad5c87b1e0f2e302d594a39a7e967822a69d68c3bda2bf7e21e49cdaff38L7-R7) [[2]](diffhunk://#diff-8ad4ad5c87b1e0f2e302d594a39a7e967822a69d68c3bda2bf7e21e49cdaff38L16-R16)
* [`recsa/assembly_drawing/drawing_3d.py`](diffhunk://#diff-43a076d70fb1673bc8f66930e554ea6e63c2c9b72040a4b03b38ff47f68ebbfcL8-R8): Replaced `ComponentStructure` with `Component` in type annotations and imports. [[1]](diffhunk://#diff-43a076d70fb1673bc8f66930e554ea6e63c2c9b72040a4b03b38ff47f68ebbfcL8-R8) [[2]](diffhunk://#diff-43a076d70fb1673bc8f66930e554ea6e63c2c9b72040a4b03b38ff47f68ebbfcL17-R17)