### PR TITLE
Delete __eq__ method of Component class

### DIFF
--- a/recsa/classes/component_structure/component_structure.py
+++ b/recsa/classes/component_structure/component_structure.py
@@ -50,12 +50,7 @@ class Component:
         self.__g_cache = None
     
     def __eq__(self, value: object) -> bool:
-        if not isinstance(value, Component):
-            return False
-        return (
-            self.__component_kind == value.__component_kind and
-            self.__binding_sites == value.__binding_sites and
-            self.__aux_edges == value.__aux_edges)
+        return NotImplemented
 
     # Decorator
     @staticmethod

--- a/recsa/classes/component_structure/tests/test_component_structure.py
+++ b/recsa/classes/component_structure/tests/test_component_structure.py
@@ -52,17 +52,6 @@ def test_init_with_empty_aux_edges() -> None:
     assert component.aux_edges == set()
 
 
-def test_eq() -> None:
-    component1 = Component('M', {'a', 'b'})
-    component2 = Component('M', {'a', 'b'})
-    component3 = Component('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
-    component4 = Component('M', {'a', 'b'}, {AuxEdge('a', 'b', 'trans')})
-
-    assert component1 == component2
-    assert component1 != component3
-    assert component3 != component4
-
-
 def test_clear_g_cache(comp) -> None:
     comp._Component__g_cache = 1
     assert comp._Component__g_cache == 1


### PR DESCRIPTION
This pull request includes changes to the `Component` class and its associated tests in the `recsa` package. The changes primarily focus on modifying the equality comparison method and removing related tests.

Changes to `Component` class:

* [`recsa/classes/component_structure/component_structure.py`](diffhunk://#diff-25dfe60e3a589174ebe5c6803e5c26e3d063318c42d8a744166e64f802ff14c0L53-R53): Modified the `__eq__` method to return `NotImplemented` instead of performing a detailed comparison of attributes.

Changes to tests:

* [`recsa/classes/component_structure/tests/test_component_structure.py`](diffhunk://#diff-fb19799b9ff09746784043dad9c0f5d050fdf52a76179c3b2ad542fe2a0dcc00L55-L65): Removed the `test_eq` function, which tested the equality of `Component` instances, as the equality logic was removed from the `Component` class.