### PR TITLE
Refactor Component class to remove component_kind property and setter

### DIFF
--- a/recsa/classes/component/component.py
+++ b/recsa/classes/component/component.py
@@ -66,16 +66,6 @@ class Component:
             self.__g_cache = None
             return func(self, *args, **kwargs)
         return wrapper
-
-    @property
-    def component_kind(self) -> str:
-        return self.__component_kind
-    
-    @component_kind.setter
-    @clear_g_cache
-    def component_kind(self, component_kind: str) -> None:
-        validate_name_of_component_kind(component_kind)
-        self.__component_kind = component_kind
     
     @property
     def binding_sites(self) -> set[str]:

--- a/recsa/classes/component/tests/test_component.py
+++ b/recsa/classes/component/tests/test_component.py
@@ -13,12 +13,10 @@ def comp_with_aux_edges() -> Component:
 
 
 def test_init_with_valid_args(comp) -> None:
-    assert comp.component_kind == 'M'
     assert set(comp.binding_sites) == {'a', 'b'}
 
 
 def test_init_with_valid_args_with_single_aux_edge(comp_with_aux_edges) -> None:
-    assert comp_with_aux_edges.component_kind == 'M'
     assert set(comp_with_aux_edges.binding_sites) == {'a', 'b'}
     assert comp_with_aux_edges.aux_edges == {AuxEdge('a', 'b', 'cis')}
 
@@ -28,7 +26,6 @@ def test_init_with_valid_args_with_multiple_aux_edges() -> None:
         AuxEdge('a', 'b', 'cis'), AuxEdge('a', 'c', 'cis'), 
         AuxEdge('b', 'c', 'trans')})
     
-    assert component.component_kind == 'M'
     assert set(component.binding_sites) == {'a', 'b', 'c'}
     assert component.aux_edges == {
         AuxEdge('a', 'b', 'cis'), AuxEdge('a', 'c', 'cis'), 


### PR DESCRIPTION
This pull request removes the `component_kind` property and its associated methods from the `Component` class and updates the relevant test cases accordingly. The most important changes include the removal of the `component_kind` property and its setter method, and the corresponding updates in the test cases to reflect this removal.

### Removal of `component_kind` property:

* [`recsa/classes/component/component.py`](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL70-L79): Removed the `component_kind` property and its setter method.

### Updates to test cases:

* [`recsa/classes/component/tests/test_component.py`](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L16-L21): Removed assertions related to `component_kind` in the `test_init_with_valid_args`, `test_init_with_valid_args_with_single_aux_edge`, and `test_init_with_valid_args_with_multiple_aux_edges` functions. [[1]](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L16-L21) [[2]](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L31)