### PR TITLE
Refactor Component class to remove g_snapshot property and related me…

### DIFF
--- a/recsa/classes/component/tests/test_component.py
+++ b/recsa/classes/component/tests/test_component.py
@@ -49,13 +49,5 @@ def test_init_with_empty_aux_edges() -> None:
     assert component.aux_edges == set()
 
 
-def test_clear_g_cache(comp) -> None:
-    comp._Component__g_cache = 1
-    assert comp._Component__g_cache == 1
-
-    comp._Component__add_binding_site('c')
-    assert comp._Component__g_cache is None
-
-
 if __name__ == '__main__':
     pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request focuses on cleaning up the `Component` class by removing the `clear_g_cache` decorator and associated methods, as well as eliminating the `_to_graph` method and its dependencies. These changes simplify the class and remove unnecessary code.

Code cleanup and simplification:

* [`recsa/classes/component/component.py`](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL55-L69): Removed the `clear_g_cache` decorator and its usage across multiple methods, including `__add_binding_site`, `__add_binding_sites`, `__remove_binding_site`, `__remove_binding_sites`, `__add_aux_edge`, `__add_aux_edges`, and `__remove_aux_edge`. [[1]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL55-L69) [[2]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL79-L85) [[3]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL100) [[4]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL111-L125) [[5]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL137-L167)
* [`recsa/classes/component/component.py`](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL79-L85): Removed the `_to_graph` method and the `g_snapshot` property, which were dependent on the `networkx` library. [[1]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL79-L85) [[2]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL137-L167)

Test cleanup:

* [`recsa/classes/component/tests/test_component.py`](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L52-L59): Removed the `test_clear_g_cache` function, which tested the `clear_g_cache` decorator functionality.…thods