### PR TITLE
Refactor Component class to remove component_kind parameter from cons…

### DIFF
--- a/recsa/algorithms/isomorphism/tests/test_isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/tests/test_isomorphism_check.py
@@ -17,12 +17,12 @@ def assem_without_bonds() -> Assembly:
 @pytest.fixture
 def component_structures() -> dict[str, Component]:
     M_COMP = Component(
-        'M', {'a', 'b', 'c', 'd'},
+        {'a', 'b', 'c', 'd'},
         {
             AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis'),})
-    L_COMP = Component('L', {'a', 'b'})
-    X_COMP = Component('X', {'a'})
+    L_COMP = Component({'a', 'b'})
+    X_COMP = Component({'a'})
     return {'M': M_COMP, 'L': L_COMP, 'X': X_COMP}
 
 

--- a/recsa/algorithms/isomorphism/tests/test_iteration.py
+++ b/recsa/algorithms/isomorphism/tests/test_iteration.py
@@ -9,11 +9,11 @@ def test_isomorphisms_iter():
         [('M1.a', 'L1.a'), ('M1.b', 'L2.a'), ('M1.c', 'X1.a'), ('M1.d', 'X2.a')])
     COMPONENT_STRUCTURES = {
         'M': Component(
-            'M', {'a', 'b', 'c', 'd'},
+            {'a', 'b', 'c', 'd'},
             {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
              AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'L': Component('L', {'a'}),
-        'X': Component('X', {'a'})}
+        'L': Component({'a'}),
+        'X': Component({'a'})}
     
     isomorphisms = list(isomorphisms_iter(ML2X2_CIS, ML2X2_CIS, COMPONENT_STRUCTURES))
 

--- a/recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py
+++ b/recsa/algorithms/isomorphism/tests/test_pure_isomorphism_check.py
@@ -18,12 +18,12 @@ def assem_without_bonds() -> Assembly:
 @pytest.fixture
 def component_structures() -> dict[str, Component]:
     M_COMP = Component(
-        'M', {'a', 'b', 'c', 'd'},
+        {'a', 'b', 'c', 'd'},
         {
             AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis'),})
-    L_COMP = Component('L', {'a', 'b'})
-    X_COMP = Component('X', {'a'})
+    L_COMP = Component({'a', 'b'})
+    X_COMP = Component({'a'})
     return {'M': M_COMP, 'L': L_COMP, 'X': X_COMP}
 
 

--- a/recsa/algorithms/ligand_exchange/tests/test_inter.py
+++ b/recsa/algorithms/ligand_exchange/tests/test_inter.py
@@ -21,9 +21,9 @@ def test_inter_exchange() -> None:
     X = X.rename_component_ids({'X1': 'init_X1'})
     
     COMPONENT_KINDS = {
-        'M': Component('M', {'a', 'b'}),
-        'L': Component('L', {'a'}),
-        'X': Component('X', {'a'})}
+        'M': Component({'a', 'b'}),
+        'L': Component({'a'}),
+        'X': Component({'a'})}
     
     product, leaving = perform_inter_exchange(
         MX2, L, 'M1.a', 'X1.a', 'L1.a')

--- a/recsa/algorithms/ligand_exchange/tests/test_intra.py
+++ b/recsa/algorithms/ligand_exchange/tests/test_intra.py
@@ -16,9 +16,9 @@ def test_intra_exchange() -> None:
     X = Assembly({'X1': 'X'}, [])
 
     COMPONENT_KINDS = {
-        'M': Component('M', {'a', 'b'}),
-        'L': Component('L', {'a', 'b'}),
-        'X': Component('X', {'a'})}
+        'M': Component({'a', 'b'}),
+        'L': Component({'a', 'b'}),
+        'X': Component({'a'})}
     
     product, leaving = perform_intra_exchange(
         MLX, 'M1.a', 'X1.a', 'L1.b')

--- a/recsa/algorithms/tests/test_aux_edge_existence.py
+++ b/recsa/algorithms/tests/test_aux_edge_existence.py
@@ -9,10 +9,10 @@ def test_has_aux_edges_true():
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'X4.a')])
     COMPONENT_STRUCTURES = {
         'M': Component(
-            'M', {'a', 'b', 'c', 'd'}, 
+            {'a', 'b', 'c', 'd'}, 
             {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
              AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'X': Component('X', {'a'})}
+        'X': Component({'a'})}
     assert has_aux_edges(MX4, COMPONENT_STRUCTURES)
 
 
@@ -21,8 +21,8 @@ def test_has_aux_edges_false():
         {'M1': 'M', 'X1': 'X', 'X2': 'X', 'X3': 'X', 'X4': 'X'},
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'X4.a')])
     COMPONENT_STRUCTURES = {
-        'M': Component('M', {'a', 'b', 'c', 'd'}),  # No aux edges
-        'X': Component('X', {'a'})}
+        'M': Component({'a', 'b', 'c', 'd'}),  # No aux edges
+        'X': Component({'a'})}
     assert not has_aux_edges(MX4, COMPONENT_STRUCTURES)
 
 
@@ -31,12 +31,12 @@ def test_has_aux_edges_false2():
         {'M1': 'M', 'X1': 'X', 'X2': 'X', 'X3': 'X', 'X4': 'X'},
         [('M1.a', 'X1.a'), ('M1.b', 'X2.a'), ('M1.c', 'X3.a'), ('M1.d', 'X4.a')])
     COMPONENT_STRUCTURES = {
-        'M': Component('M', {'a', 'b', 'c', 'd'}),  # No aux edges
+        'M': Component({'a', 'b', 'c', 'd'}),  # No aux edges
         'L': Component(
-            'L', {'a', 'b', 'c', 'd'},
+            {'a', 'b', 'c', 'd'},
             {AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
              AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),  # Aux edges but not in assembly
-        'X': Component('X', {'a'})}
+        'X': Component({'a'})}
     assert not has_aux_edges(MX4, COMPONENT_STRUCTURES)
 
 

--- a/recsa/assembly_drawing/tests/test_drawing_2d.py
+++ b/recsa/assembly_drawing/tests/test_drawing_2d.py
@@ -12,11 +12,11 @@ def test_draw_2d():
     )
     COMPONENT_STRUCTURES = {
         'M': Component(
-            'M', {'a', 'b', 'c', 'd'}, {
+            {'a', 'b', 'c', 'd'}, {
                 AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
                 AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'L': Component('L', {'a', 'b'}),
-        'X': Component('X', {'a'}),
+        'L': Component({'a', 'b'}),
+        'X': Component({'a'}),
     }
 
     positions = nx.spring_layout(MLX3.g_snapshot(COMPONENT_STRUCTURES))

--- a/recsa/assembly_drawing/tests/test_drawing_3d.py
+++ b/recsa/assembly_drawing/tests/test_drawing_3d.py
@@ -12,11 +12,11 @@ def test_draw_3d():
     )
     COMPONENT_STRUCTURES = {
         'M': Component(
-            'M', {'a', 'b', 'c', 'd'}, {
+            {'a', 'b', 'c', 'd'}, {
                 AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
                 AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')}),
-        'L': Component('L', {'a', 'b'}),
-        'X': Component('X', {'a'}),
+        'L': Component({'a', 'b'}),
+        'X': Component({'a'}),
     }
 
     positions = nx.spring_layout(

--- a/recsa/classes/component/component.py
+++ b/recsa/classes/component/component.py
@@ -14,7 +14,7 @@ class Component:
     """A component of an assembly."""
 
     def __init__(
-            self, component_kind: str, 
+            self,
             binding_sites: set[str],
             aux_edges: set[AuxEdge] | None = None):
         """
@@ -31,9 +31,6 @@ class Component:
             Duplicate pairs of binding sites raise an error regardless of the
             order of the binding sites.
         """
-        validate_name_of_component_kind(component_kind)
-        self.__component_kind = component_kind
-
         for bindsite in binding_sites:
             validate_name_of_binding_site(bindsite)
         self.__binding_sites = binding_sites.copy()

--- a/recsa/classes/component/tests/test_component.py
+++ b/recsa/classes/component/tests/test_component.py
@@ -5,11 +5,11 @@ from recsa import AuxEdge, Component, RecsaValueError
 
 @pytest.fixture
 def comp() -> Component:
-    return Component('M', {'a', 'b'})
+    return Component({'a', 'b'})
 
 @pytest.fixture
 def comp_with_aux_edges() -> Component:
-    return Component('M', {'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+    return Component({'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
 
 
 def test_init_with_valid_args(comp) -> None:
@@ -22,7 +22,7 @@ def test_init_with_valid_args_with_single_aux_edge(comp_with_aux_edges) -> None:
 
 
 def test_init_with_valid_args_with_multiple_aux_edges() -> None:
-    component = Component('M', {'a', 'b', 'c'}, {
+    component = Component({'a', 'b', 'c'}, {
         AuxEdge('a', 'b', 'cis'), AuxEdge('a', 'c', 'cis'), 
         AuxEdge('b', 'c', 'trans')})
     
@@ -34,18 +34,18 @@ def test_init_with_valid_args_with_multiple_aux_edges() -> None:
 
 def test_init_with_invalid_aux_edge_whose_binding_sites_not_in_binding_sites() -> None:
     with pytest.raises(RecsaValueError):
-        Component('M', {'a', 'b'}, {AuxEdge('a', 'c', 'cis')})
+        Component({'a', 'b'}, {AuxEdge('a', 'c', 'cis')})
 
 
 def test_init_with_empty_binding_sites() -> None:
     # Empty binding sites is allowed.
-    component = Component('M', set())
+    component = Component(set())
     assert component.binding_sites == set()
 
 
 def test_init_with_empty_aux_edges() -> None:
     # Empty aux_edges is allowed.
-    component = Component('M', {'a', 'b'}, set())
+    component = Component({'a', 'b'}, set())
     assert component.aux_edges == set()
 
 

--- a/recsa/classes/tests/test_assembly.py
+++ b/recsa/classes/tests/test_assembly.py
@@ -5,13 +5,13 @@ from recsa import Assembly, AuxEdge, Component
 
 @pytest.fixture
 def M_COMP() -> Component:
-    return Component('M', {'a', 'b', 'c', 'd'})
+    return Component({'a', 'b', 'c', 'd'})
 
 
 @pytest.fixture
 def M_WITH_AUX_EDGES() -> Component:
     return Component(
-        'M', {'a', 'b', 'c', 'd'}, 
+        {'a', 'b', 'c', 'd'}, 
         {
             AuxEdge('a', 'b', 'cis'), AuxEdge('b', 'c', 'cis'),
             AuxEdge('c', 'd', 'cis'), AuxEdge('d', 'a', 'cis')
@@ -20,12 +20,12 @@ def M_WITH_AUX_EDGES() -> Component:
 
 @pytest.fixture
 def L_COMP() -> Component:
-    return Component('L', {'a', 'b'})
+    return Component({'a', 'b'})
 
 
 @pytest.fixture
 def X_COMP() -> Component:
-    return Component('X', {'a'})
+    return Component({'a'})
 
 
 def test_init_with_no_args() -> None:

--- a/recsa/duplicate_exclusion/lib/tests/test_grouping_by_isomorphism.py
+++ b/recsa/duplicate_exclusion/lib/tests/test_grouping_by_isomorphism.py
@@ -23,9 +23,9 @@ def test_group_assemblies_by_isomorphism():
             []),
     }
     component_structures = {
-        'M': Component('M', {'a', 'b'}),
-        'L': Component('L', {'a', 'b'}),
-        'X': Component('X', {'a'}),
+        'M': Component({'a', 'b'}),
+        'L': Component({'a', 'b'}),
+        'X': Component({'a'}),
     }
 
     grouped_ids = group_assemblies_by_isomorphism(id_to_graph, component_structures)

--- a/recsa/loading/component_structures.py
+++ b/recsa/loading/component_structures.py
@@ -62,5 +62,5 @@ def create_component_structures_from_data(
                     kind = aux_edge.kind
                     aux_edges.add(AuxEdge(bindsite1, bindsite2, kind))
         component_structures[component_structure.id] = Component(
-            component_structure.id, bindsites, aux_edges)
+            bindsites, aux_edges)
     return component_structures

--- a/recsa/loading/structure_data.py
+++ b/recsa/loading/structure_data.py
@@ -77,7 +77,7 @@ def load_yaml(file_path: str | Path) -> StructureData:
 def convert_data_to_args(data: StructureData) -> Args:
     component_structures = {
         comp_kind.id: Component(
-            comp_kind.id, set(comp_kind.bindsites),
+            set(comp_kind.bindsites),
             {AuxEdge(edge.bindsites[0], edge.bindsites[1], edge.kind)
              for edge in comp_kind.aux_edges or []})
         for comp_kind in data.component_structures


### PR DESCRIPTION
This pull request includes changes to the `Component` class and its usage across various test files to remove the `component_kind` parameter. The changes ensure consistency in the way `Component` instances are initialized.

### Changes to `Component` class

* [`recsa/classes/component/component.py`](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL17-R17): Removed the `component_kind` parameter from the `Component` class constructor and associated validation. [[1]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL17-R17) [[2]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL34-L36)

### Updates to test files

* [`recsa/algorithms/isomorphism/tests/test_isomorphism_check.py`](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L20-R25): Updated `Component` initialization to remove the `component_kind` parameter. [[1]](diffhunk://#diff-1908971a3a057038c5e445bc1381915a974459bc52689027b43232373b9cda49L20-R25) [[2]](diffhunk://#diff-b2f35fcec4b35fc62491cc0879b3d292f3b6cc43eba991a63149be5491d1bef4L21-R26)
* [`recsa/algorithms/isomorphism/tests/test_iteration.py`](diffhunk://#diff-c93a2df085b60bb5fa45b601a15a1b5184f3bcd477d2b283382f438a81e4acaeL12-R16): Updated `Component` initialization to remove the `component_kind` parameter.
* [`recsa/algorithms/ligand_exchange/tests/test_inter.py`](diffhunk://#diff-3573dc145edb5452d3dfd4b5a2d4c0c2efddf38605d2afe354e1251c9dc19442L24-R26): Updated `Component` initialization to remove the `component_kind` parameter.
* [`recsa/algorithms/ligand_exchange/tests/test_intra.py`](diffhunk://#diff-013b6f764b149e564149609a2cf6ef5df0e4089f6095f29ec33c2be490413648L19-R21): Updated `Component` initialization to remove the `component_kind` parameter.
* [`recsa/algorithms/tests/test_aux_edge_existence.py`](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L12-R15): Updated `Component` initialization to remove the `component_kind` parameter. [[1]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L12-R15) [[2]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L24-R25) [[3]](diffhunk://#diff-db6c02ad6324d37772040bc91f3ad41f8585a55e1fd744ff429945d401edcd42L34-R39)
* [`recsa/assembly_drawing/tests/test_drawing_2d.py`](diffhunk://#diff-62bc0c8495907d1dd84181d78c2ae7a454cdb36ae3fed24fd95690e14e6f068bL15-R19): Updated `Component` initialization to remove the `component_kind` parameter.
* [`recsa/assembly_drawing/tests/test_drawing_3d.py`](diffhunk://#diff-dbcee1183f535ee3c097e96331eba8ff78b6ce450ee042cda2e3e78f00763054L15-R19): Updated `Component` initialization to remove the `component_kind` parameter.
* [`recsa/classes/component/tests/test_component.py`](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L8-R12): Updated `Component` initialization to remove the `component_kind` parameter. [[1]](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L8-R12) [[2]](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L25-R25) [[3]](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L37-R48)
* [`recsa/classes/tests/test_assembly.py`](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bL8-R14): Updated `Component` initialization to remove the `component_kind` parameter. [[1]](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bL8-R14) [[2]](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bL23-R28)
* [`recsa/duplicate_exclusion/lib/tests/test_grouping_by_isomorphism.py`](diffhunk://#diff-b5d83c31db18403f252596883d3075d1dd5294ebfdbee20534613efb338984b8L26-R28): Updated `Component` initialization to remove the `component_kind` parameter.

### Changes to loading functions

* [`recsa/loading/component_structures.py`](diffhunk://#diff-97d07896db6e21429abf06a2fc5b2dec3ab74be3a87e6f13aadf36274be78db6L65-R65): Updated `Component` initialization in `create_component_structures_from_data` to remove the `component_kind` parameter.
* [`recsa/loading/structure_data.py`](diffhunk://#diff-0613ae287399e247f8116e1a7f7482dc296b4b2895bc490baf11d91c5dc713a6L80-R80): Updated `Component` initialization in `convert_data_to_args` to remove the `component_kind` parameter.…tructor