### PR TITLE
Chore/rename bindsites

### DIFF
--- a/recsa/classes/assembly.py
+++ b/recsa/classes/assembly.py
@@ -329,7 +329,7 @@ class Assembly:
         all_bindsites = set()
         for comp_id, comp_kind in self.component_id_to_kind.items():
             comp_struct = component_structures[comp_kind]
-            for bindsite in comp_struct.binding_sites:
+            for bindsite in comp_struct.bindsites:
                 all_bindsites.add(id_converter.local_to_global(comp_id, bindsite))
         return all_bindsites
 
@@ -357,7 +357,7 @@ class Assembly:
         comp_struct = component_structures[comp_kind]
         return {
             id_converter.local_to_global(component_id, bindsite)
-            for bindsite in comp_struct.binding_sites}
+            for bindsite in comp_struct.bindsites}
     
     def get_all_bindsites_of_kind(
             self, component_kind: str,
@@ -376,7 +376,7 @@ class Assembly:
         all_bindsites = {
             id_converter.local_to_global(comp_id, bindsite)
             for comp_id, comp_kind in self.component_id_to_kind.items()
-            for bindsite in component_structures[comp_kind].binding_sites
+            for bindsite in component_structures[comp_kind].bindsites
         }
         connected_bindsites = chain(*self.bonds)
         free_bindsites = all_bindsites - set(connected_bindsites)
@@ -436,7 +436,7 @@ def add_component_to_graph(
         core_abs, core_or_bindsite='core', component_kind=component_kind)
     
     # Add the binding sites
-    for bindsite in component_structure.binding_sites:
+    for bindsite in component_structure.bindsites:
         bindsite_abs = id_converter.local_to_global(component_id, bindsite)
         g.add_node(bindsite_abs, core_or_bindsite='bindsite')
         g.add_edge(core_abs, bindsite_abs)

--- a/recsa/classes/component/component.py
+++ b/recsa/classes/component/component.py
@@ -53,7 +53,7 @@ class Component:
         return NotImplemented
     
     @property
-    def binding_sites(self) -> set[str]:
+    def bindsites(self) -> set[str]:
         return set(self._bindsites)
 
     @property

--- a/recsa/classes/component/tests/test_component.py
+++ b/recsa/classes/component/tests/test_component.py
@@ -9,21 +9,21 @@ def test_typical_usage():
     aux_edges = [('a', 'b', 'cis'), ('b', 'c', 'cis'),
                  ('c', 'd', 'cis'), ('d', 'a', 'cis')]
     M = Component(bindsites, aux_edges)
-    assert M.binding_sites == set(bindsites)
+    assert M.bindsites == set(bindsites)
     assert M.aux_edges == {AuxEdge(*edge) for edge in aux_edges}
 
 
 def test_init():
     bindsites = {'a', 'b'}
     M = Component(bindsites)
-    assert M.binding_sites == bindsites
+    assert M.bindsites == bindsites
     assert M.aux_edges == set()
 
 
 def test_init_with_bindsites_of_type_tuple():
     bindsites = ['a', 'b']
     M = Component(bindsites)
-    assert M.binding_sites == set(bindsites)
+    assert M.bindsites == set(bindsites)
     assert M.aux_edges == set()
 
 
@@ -31,7 +31,7 @@ def test_init_with_aux_edges():
     bindsites = {'a', 'b'}
     aux_edges = {AuxEdge('a', 'b', 'cis')}
     M = Component(bindsites, aux_edges)
-    assert M.binding_sites == bindsites
+    assert M.bindsites == bindsites
     assert M.aux_edges == aux_edges
 
 
@@ -39,14 +39,14 @@ def test_init_with_aux_edges_of_type_tuple():
     bindsites = {'a', 'b'}
     aux_edges = [('a', 'b', 'cis')]
     M = Component(bindsites, aux_edges)
-    assert M.binding_sites == bindsites
+    assert M.bindsites == bindsites
     assert M.aux_edges == {AuxEdge(*edge) for edge in aux_edges}
 
 
 def test_init_with_empty_binding_sites():
     # Raises no error.
     M = Component(set())
-    assert M.binding_sites == set()
+    assert M.bindsites == set()
 
 
 def test_init_with_empty_aux_edges():


### PR DESCRIPTION
This pull request includes a series of changes to rename the `binding_sites` attribute to `bindsites` across multiple files in the `recsa` module. This change aims to standardize the terminology used for binding sites within the codebase.

### Terminology Update:

* [`recsa/classes/assembly.py`](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L332-R332): Updated all instances of `binding_sites` to `bindsites` in methods `get_all_bindsites`, `get_bindsites_of_component`, `find_free_bindsites`, and `add_component_to_graph`. [[1]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L332-R332) [[2]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L360-R360) [[3]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L379-R379) [[4]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L439-R439)
* [`recsa/classes/component/component.py`](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL16-R16): Changed the `binding_sites` attribute to `bindsites` in the `Component` class and its `__init__` method. Updated related property and validation logic. [[1]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL16-R16) [[2]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL35-R37) [[3]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL50-R57)

### Test Updates:

* [`recsa/classes/component/tests/test_component.py`](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L12-R49): Updated all test cases to use `bindsites` instead of `binding_sites` to reflect the changes in the `Component` class.