### PR TITLE
Refactor Component class __eq__ method to compare bindsites and aux_edges

### DIFF
--- a/recsa/classes/component/component.py
+++ b/recsa/classes/component/component.py
@@ -50,7 +50,11 @@ class Component:
             self._aux_edges, self._bindsites)
     
     def __eq__(self, value: object) -> bool:
-        return NotImplemented
+        if not isinstance(value, Component):
+            return False
+        return (
+            self.bindsites == value.bindsites
+            and self.aux_edges == value.aux_edges)
     
     @property
     def bindsites(self) -> set[str]:

--- a/recsa/classes/component/tests/test_component.py
+++ b/recsa/classes/component/tests/test_component.py
@@ -61,5 +61,23 @@ def test_init_with_invalid_aux_edge():
         Component({'a', 'b'}, {AuxEdge('a', 'c', 'cis')})
 
 
+def test_eq():
+    M1 = Component({'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+    M2 = Component({'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+    assert M1 == M2
+
+
+def test_eq_with_different_binding_sites():
+    M1 = Component({'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+    M2 = Component({'a', 'c'}, {AuxEdge('a', 'c', 'cis')})
+    assert M1 != M2
+
+
+def test_eq_with_different_aux_edges():
+    M1 = Component({'a', 'b'}, {AuxEdge('a', 'b', 'cis')})
+    M2 = Component({'a', 'b'}, {AuxEdge('a', 'b', 'trans')})
+    assert M1 != M2
+
+
 if __name__ == '__main__':
     pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request includes changes to the `Component` class and its corresponding test cases to implement and verify the equality comparison method.

### Enhancements to `Component` class:

* [`recsa/classes/component/component.py`](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL53-R57): Implemented the `__eq__` method to compare `Component` instances based on their `bindsites` and `aux_edges` attributes.

### Additions to test cases:

* [`recsa/classes/component/tests/test_component.py`](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6R64-R81): Added new test cases to verify the equality comparison method for `Component` instances, including tests for identical components, components with different binding sites, and components with different auxiliary edges.