### PR TITLE
Add InterReactionEmbedded and InterReactionEmbedded classes

### DIFF
--- a/recsa/classes/__init__.py
+++ b/recsa/classes/__init__.py
@@ -6,5 +6,7 @@ from .component import Component
 from .mle import MleBindsite
 from .mle import MleKind
 from .reaction import InterReaction
+from .reaction import InterReactionEmbedded
 from .reaction import IntraReaction
+from .reaction import IntraReactionEmbedded
 from .bindsite_id_converter import BindsiteIdConverter

--- a/recsa/classes/reaction.py
+++ b/recsa/classes/reaction.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import ClassVar
 
+from .assembly import Assembly
+
 
 @dataclass
 class IntraReaction:
@@ -23,6 +25,36 @@ class InterReaction:
     entering_assem_id: str
     product_assem_id: str
     leaving_assem_id: str | None
+    metal_bs: str
+    leaving_bs: str
+    entering_bs: str
+    metal_kind: str
+    leaving_kind: str
+    entering_kind: str
+    duplicate_count: int
+
+
+@dataclass
+class IntraReactionEmbedded:
+    init_assem: Assembly
+    entering_assem: ClassVar[None] = None
+    product_assem: Assembly
+    leaving_assem: Assembly | None
+    metal_bs: str
+    leaving_bs: str
+    entering_bs: str
+    metal_kind: str
+    leaving_kind: str
+    entering_kind: str
+    duplicate_count: int
+
+
+@dataclass
+class InterReactionEmbedded:
+    init_assem: Assembly
+    entering_assem: Assembly
+    product_assem: Assembly
+    leaving_assem: Assembly | None
     metal_bs: str
     leaving_bs: str
     entering_bs: str


### PR DESCRIPTION
This pull request introduces new embedded reaction classes and updates the import statements accordingly. The most important changes include adding new classes for embedded reactions and updating the import statements in the `recsa/classes/__init__.py` file.

### New Embedded Reaction Classes:
* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907R35-R64): Added `IntraReactionEmbedded` and `InterReactionEmbedded` classes to handle embedded reactions.

### Import Statement Updates:
* [`recsa/classes/__init__.py`](diffhunk://#diff-e49c189f09b4c2e850a4ec1f2399e71ea487f6f6c41ab13a197aa0c104346a7cR9-R11): Updated import statements to include `InterReactionEmbedded` and `IntraReactionEmbedded` classes.
* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907R4-R5): Added import statement for `Assembly`.