### PR TITLE
Refactor key name of yaml file from 'components' to 'comp_kinds'

### DIFF
--- a/recsa/loading/components.py
+++ b/recsa/loading/components.py
@@ -20,7 +20,7 @@ def create_component_structures_from_data(
         data: Any) -> dict[str, Component]:
     """Create ComponentStructure objects from a dictionary."""
     # Expected format:
-    # {'components': {
+    # {'comp_kinds': {
     #     'M': {
     #         'bindsites': ['a', 'b'],
     #         'aux_edges': [['a', 'b', 'cis']]
@@ -32,10 +32,10 @@ def create_component_structures_from_data(
 
     if not isinstance(data, dict):
         raise ValueError('Expected a dictionary')
-    if 'components' not in data:
-        raise ValueError('Expected a key "component_structures"')
+    if 'comp_kinds' not in data:
+        raise ValueError('Expected a key "comp_kinds"')
     
-    comp_kind_to_data = data['components']
+    comp_kind_to_data = data['comp_kinds']
     if not isinstance(comp_kind_to_data, dict):
         raise ValueError('Expected a dictionary')
     

--- a/recsa/loading/tests/test_components.py
+++ b/recsa/loading/tests/test_components.py
@@ -6,7 +6,7 @@ from recsa import Component, load_component_structures
 
 # Helper function
 def write_safe_data_to_file(tmp_path, data):
-    file = tmp_path / 'components.yaml'
+    file = tmp_path / 'comp_kinds.yaml'
     with file.open('w') as f:
         yaml.safe_dump(data, f)
     return file
@@ -18,7 +18,7 @@ def test_typical_case(tmp_path):
               'aux_edges': [['a', 'b', 'cis']]},
         'X': {'bindsites': ['a'],}
     }
-    data = {'components': COMPONENTS}
+    data = {'comp_kinds': COMPONENTS}
 
     component_structures_file = write_safe_data_to_file(tmp_path, data)
     
@@ -33,7 +33,7 @@ def test_typical_case(tmp_path):
 
 def test_component_without_bindsites(tmp_path):
     COMPONENTS: dict[str, dict] = {'M': {}}
-    data = {'components': COMPONENTS}
+    data = {'comp_kinds': COMPONENTS}
 
     component_structures_file = write_safe_data_to_file(tmp_path, data)
     
@@ -44,7 +44,7 @@ def test_component_without_bindsites(tmp_path):
 
 def test_component_without_aux_edges(tmp_path):
     COMPONENTS: dict[str, dict] = {'M': {'bindsites': ['a']}}
-    data = {'components': COMPONENTS}
+    data = {'comp_kinds': COMPONENTS}
 
     component_structures_file = write_safe_data_to_file(tmp_path, data)
     


### PR DESCRIPTION
This pull request includes several changes to the `recsa/loading` module to update the terminology from "components" to "comp_kinds". The most important changes involve updating the function `create_component_structures_from_data` and related test cases to use the new terminology.

Changes in `recsa/loading/components.py`:

* Updated the expected dictionary format in the `create_component_structures_from_data` function from `'components'` to `'comp_kinds'`.
* Modified the key checks and variable names inside `create_component_structures_from_data` to reflect the change from `'components'` to `'comp_kinds'`.

Changes in `recsa/loading/tests/test_components.py`:

* Updated the file name in the `write_safe_data_to_file` helper function from `'components.yaml'` to `'comp_kinds.yaml'`.
* Modified test data in `test_typical_case`, `test_component_without_bindsites`, and `test_component_without_aux_edges` to use `'comp_kinds'` instead of `'components'`. [[1]](diffhunk://#diff-0634d7d6875b671930ead5a1ad57fedeff9ea655794c88b51fdcb31c29bb84e5L21-R21) [[2]](diffhunk://#diff-0634d7d6875b671930ead5a1ad57fedeff9ea655794c88b51fdcb31c29bb84e5L36-R36) [[3]](diffhunk://#diff-0634d7d6875b671930ead5a1ad57fedeff9ea655794c88b51fdcb31c29bb84e5L47-R47)