### PR TITLE
Refactor key name of yaml file from 'components' to 'comp_kinds'

### DIFF
--- a/recsa/loading/structure_data.py
+++ b/recsa/loading/structure_data.py
@@ -50,7 +50,7 @@ class BondData(BaseModel):
 class StructureData(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True)
     
-    component_structures: list[ComponentStructureData]
+    comp_kinds: list[ComponentStructureData]
     components: list[ComponentData]
     bonds: list[BondData] | None = None
 


### PR DESCRIPTION
This pull request includes a change to the `StructureData` class in the `recsa/loading/structure_data.py` file. The change involves renaming a class attribute to improve clarity.

* [`recsa/loading/structure_data.py`](diffhunk://#diff-0613ae287399e247f8116e1a7f7482dc296b4b2895bc490baf11d91c5dc713a6L53-R53): Renamed the `component_structures` attribute to `comp_kinds` in the `StructureData` class.