### PR TITLE
Refactor aux_edges in ComponentStructureData to use tuple instead of …

### DIFF
--- a/recsa/loading/structure_data.py
+++ b/recsa/loading/structure_data.py
@@ -18,18 +18,11 @@ class Args:
     bond_id_to_bindsites: dict[str, frozenset[str]]
 
 
-class AuxEdgeData(BaseModel):
-    model_config = ConfigDict(coerce_numbers_to_str=True)
-
-    bindsites: tuple[str, str]
-    kind: str
-
-
 class ComponentStructureData(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True)
 
     bindsites: list[str]
-    aux_edges: list[AuxEdgeData] | None = None
+    aux_edges: list[tuple[str, str, str]] | None = None
 
 
 class ComponentData(BaseModel):
@@ -77,8 +70,7 @@ def convert_data_to_args(data: StructureData) -> Args:
     comp_kinds = {
         kind_id: Component(
             set(comp_data.bindsites),
-            {AuxEdge(edge.bindsites[0], edge.bindsites[1], edge.kind)
-             for edge in comp_data.aux_edges or []})
+            {AuxEdge(*edge) for edge in comp_data.aux_edges or []})
         for kind_id, comp_data in data.comp_kinds.items()
     }
     components = {comp.id: comp.kind for comp in data.components}


### PR DESCRIPTION
This pull request includes changes to the `recsa/loading/structure_data.py` file to simplify the data structure and improve code readability. The most important changes include removing the `AuxEdgeData` class and updating the `ComponentStructureData` class and the `convert_data_to_args` function accordingly.

Simplification of data structures:

* Removed the `AuxEdgeData` class from `recsa/loading/structure_data.py` and replaced it with a tuple in the `ComponentStructureData` class. (`recsa/loading/structure_data.py`)
* Updated the `convert_data_to_args` function to handle the new tuple structure instead of the `AuxEdgeData` class. (`recsa/loading/structure_data.py`)…AuxEdgeData class