### PR TITLE
Feature/reaction classification

### DIFF
--- a/recsa/algorithms/__init__.py
+++ b/recsa/algorithms/__init__.py
@@ -26,7 +26,7 @@ from .isomorphism import is_isomorphic
 from .isomorphism import isomorphisms_iter
 from .ligand_exchange import perform_inter_exchange
 from .ligand_exchange import perform_intra_exchange
-from .reaction_embedding import embed_assemblies_into_reactions
+from .reaction_embedding import embed_assemblies_into_reaction
 from .subassembly import bond_induced_sub_assembly
 from .subassembly import component_induced_sub_assembly
 from .union import union_assemblies

--- a/recsa/algorithms/reaction_embedding.py
+++ b/recsa/algorithms/reaction_embedding.py
@@ -5,16 +5,16 @@ from recsa import (Assembly, InterReaction, InterReactionEmbedded,
 
 
 @overload
-def embed_assemblies_into_reactions(
+def embed_assemblies_into_reaction(
     reaction: IntraReaction,
     id_to_assembly: dict[str, Assembly]
     ) -> IntraReactionEmbedded: ...
 @overload
-def embed_assemblies_into_reactions(
+def embed_assemblies_into_reaction(
     reaction: InterReaction,
     id_to_assembly: dict[str, Assembly]
     ) -> InterReactionEmbedded: ...
-def embed_assemblies_into_reactions(
+def embed_assemblies_into_reaction(
         reaction: IntraReaction | InterReaction,
         id_to_assembly: dict[str, Assembly]):
     """Embed the assemblies into the reaction."""

--- a/recsa/algorithms/tests/test_reaction_embedding.py
+++ b/recsa/algorithms/tests/test_reaction_embedding.py
@@ -2,7 +2,7 @@ import pytest
 
 from recsa import (Assembly, InterReaction, InterReactionEmbedded,
                    IntraReaction, IntraReactionEmbedded,
-                   embed_assemblies_into_reactions)
+                   embed_assemblies_into_reaction)
 
 
 def test_inter():
@@ -21,7 +21,7 @@ def test_inter():
         'X': Assembly({'X1': 'X'}),
     }
         
-    embed_reaction = embed_assemblies_into_reactions(
+    embed_reaction = embed_assemblies_into_reaction(
         REACTION, ID_TO_ASSEMBLY)
     
     assert embed_reaction == InterReactionEmbedded(
@@ -47,7 +47,7 @@ def test_intra():
         'X': Assembly({'X1': 'X'}),
     }
     
-    embed_reaction = embed_assemblies_into_reactions(
+    embed_reaction = embed_assemblies_into_reaction(
         REACTION, ID_TO_ASSEMBLY)
     
     assert embed_reaction == IntraReactionEmbedded(


### PR DESCRIPTION
This pull request introduces a new function to embed assemblies into reactions and includes corresponding tests. The most important changes are detailed below:

### New Functionality:

* [`recsa/algorithms/reaction_embedding.py`](diffhunk://#diff-b18b9b819a762a41e2f12edd644634dbba13117c12dfd613ed22e901e3fa4728R1-R45): Added the `embed_assemblies_into_reaction` function to embed assemblies into both `IntraReaction` and `InterReaction` types. This function uses type annotations and overloads to handle different reaction types.

### Testing:

* [`recsa/algorithms/tests/test_reaction_embedding.py`](diffhunk://#diff-5164e44bb53dc128e3099801fb64728426ccd18bd96446f578255d118eabc236R1-R61): Added tests for the `embed_assemblies_into_reaction` function, covering both `IntraReaction` and `InterReaction` cases to ensure correctness.

### Imports:

* [`recsa/algorithms/__init__.py`](diffhunk://#diff-9bb557ca9a38708a55fbfbd580b5e0afbb333ce024e4f591353905c9090199b2R29): Added an import statement for the `embed_assemblies_into_reaction` function to make it accessible from the `recsa.algorithms` module.