### PR TITLE
Add count_connected function and its tests

### DIFF
--- a/recsa/reaction_classification/utils/__init__.py
+++ b/recsa/reaction_classification/utils/__init__.py
@@ -1,3 +1,4 @@
 from .bindsite_num import get_connected_num
+from .connected_comp_count import count_connected
 from .inter_or_intra_judgement import inter_or_intra
 from .nth_site_on_metal import calc_nth_site_on_metal

--- a/recsa/reaction_classification/utils/connected_comp_count.py
+++ b/recsa/reaction_classification/utils/connected_comp_count.py
@@ -1,0 +1,25 @@
+from collections.abc import Mapping
+
+from recsa import Assembly, BindsiteIdConverter, Component
+
+
+def count_connected(
+        assembly: Assembly, comp_id: str, target_comp_kind: str,
+        comp_kind_to_obj: Mapping[str, Component]
+        ) -> int:
+    """Count the number of connected components of a certain kind."""
+    id_converter = BindsiteIdConverter()
+    num = 0
+
+    for bindsite in assembly.get_bindsites_of_component(
+            comp_id, comp_kind_to_obj):
+        connected = assembly.get_connected_bindsite(bindsite)
+        if connected is None:
+            continue
+        if target_comp_kind is not None:
+            if assembly.get_component_kind_of_bindsite(connected) == target_comp_kind:
+                num += 1
+        else:
+            num += 1
+
+    return num

--- a/recsa/reaction_classification/utils/tests/test_connected_comp_count.py
+++ b/recsa/reaction_classification/utils/tests/test_connected_comp_count.py
@@ -1,0 +1,23 @@
+import pytest
+
+from recsa import Assembly, Component
+from recsa.reaction_classification.utils import count_connected
+
+
+def test():
+    MLX = Assembly({'M1': 'M', 'L1': 'L', 'X1': 'X'},
+                   [('M1.a', 'L1.a'), ('M1.b', 'X1.a')])
+    COMP_KIND_TO_OBJ = {
+        'M': Component(['a', 'b']),
+        'L': Component(['a', 'b']),
+        'X': Component(['a'])
+    }
+    
+    connected_num = count_connected(
+        MLX, 'M1', 'L', COMP_KIND_TO_OBJ)
+    
+    assert connected_num == 1
+
+
+if __name__ == '__main__':
+    pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request introduces a new utility function to count connected components and includes corresponding tests. The changes add the new function to the appropriate module, update the `__init__.py` file to import it, and provide a test case to ensure its correctness.

New utility function and tests:

* [`recsa/reaction_classification/utils/connected_comp_count.py`](diffhunk://#diff-83a24c0ead0a955574fbc8bbb9412db89713244f1a4d5573a8fe9b44e6855cedR1-R25): Added the `count_connected` function to count the number of connected components of a certain kind in an assembly.
* [`recsa/reaction_classification/utils/tests/test_connected_comp_count.py`](diffhunk://#diff-21f52ca3345db522b6309c8bcd4bfb13a3788f7ac9672b495ed4fb8f7832cca9R1-R23): Added a test case for the `count_connected` function using `pytest`.

Import updates:

* [`recsa/reaction_classification/utils/__init__.py`](diffhunk://#diff-801480c79bf25951a7dee3e75dfcd842888c3a045976938ac33285f053b45c81R2): Added an import statement for the newly created `count_connected` function.