### PR TITLE
Fix Assembly._to_rough_graph class to return MultiGraph for assemblies with parallel bonds

### DIFF
--- a/recsa/classes/assembly.py
+++ b/recsa/classes/assembly.py
@@ -387,7 +387,7 @@ class Assembly:
 
     def _to_rough_graph(self) -> nx.Graph:
         id_converter = BindsiteIdConverter()
-        G = nx.Graph()
+        G = nx.MultiGraph()
         for comp_id, comp_kind in self.comp_id_to_kind.items():
             G.add_node(comp_id, component_kind=comp_kind)
         for bindsite1, bindsite2 in self.bonds:

--- a/recsa/classes/tests/test_assembly.py
+++ b/recsa/classes/tests/test_assembly.py
@@ -1,3 +1,4 @@
+import networkx as nx
 import pytest
 
 from recsa import Assembly, AuxEdge, Component
@@ -60,6 +61,25 @@ def test_add_component() -> None:
     assert assembly.bonds == {
         frozenset(['M1.a', 'X1.a']), frozenset(['M1.b', 'X1.a']),
         frozenset(['M1.c', 'X2.a']), frozenset(['M1.d', 'X3.a'])}
+
+
+def test_rough_g_snapshot():
+    # Test for Issue #31: 
+    # https://github.com/Hiraoka-Group/recsa/issues/31#issue-2617886112
+    
+    # In cases where the assembly has parallel bonds, i.e., multiple bonds
+    # between the same pair of components, the rough_g_snapshot method 
+    # should return a MultiGraph with multiple edges between the same pair
+    # of nodes.
+
+    ML_RING = Assembly({'M1': 'M', 'L1': 'L'},
+                       [('M1.a', 'L1.a'), ('M1.b', 'L1.b')])
+
+    rough_g = ML_RING.rough_g_snapshot
+    
+    assert isinstance(rough_g, nx.MultiGraph)
+    assert [set(e) for e in rough_g.edges()] == [
+        {'M1', 'L1'}, {'M1', 'L1'}]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes changes to the `recsa` package to address an issue with handling parallel bonds in assemblies. The most important changes include updating the graph type used in the `_to_rough_graph` method and adding a new test to ensure correct behavior.

Changes to graph handling:

* [`recsa/classes/assembly.py`](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L390-R390): Changed the graph type from `nx.Graph` to `nx.MultiGraph` in the `_to_rough_graph` method to handle multiple bonds between the same pair of components.

Testing improvements:

* [`recsa/classes/tests/test_assembly.py`](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bR66-R84): Added a new test `test_rough_g_snapshot` to verify that the `rough_g_snapshot` method returns a `MultiGraph` with multiple edges between the same pair of nodes, addressing Issue #31.
* [`recsa/classes/tests/test_assembly.py`](diffhunk://#diff-cb3469160fea6d185aece9fa719b90cac5f054c4d1dd852f72403a7da8371d7bR1): Imported `networkx` as `nx` to support the new test.