### PR TITLE
Fix tests of find_shortest_cycle to allow reverse permutations

### DIFF
--- a/recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py
+++ b/recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py
@@ -25,7 +25,8 @@ def test_one_ring():
          ('M2.b', 'L2.a'), ('L2.b', 'M1.a')])
     result = find_shortest_cycle(M2L2_RING)
     assert result is not None
-    assert are_same_circular_perm(result, ['M1', 'L1', 'M2', 'L2'])
+    assert are_same_circular_perm(
+        result, ['M1', 'L1', 'M2', 'L2'], consider_reverse=True)
 
 
 def test_one_parallel():
@@ -44,7 +45,8 @@ def test_one_parallel():
     
     result = find_shortest_cycle(ML_RING)
     assert result is not None
-    assert are_same_circular_perm(result, ['M1', 'L1'])
+    assert are_same_circular_perm(
+        result, ['M1', 'L1'], consider_reverse=True)
 
 
 def test_multi_rings_of_same_length():
@@ -67,9 +69,12 @@ def test_multi_rings_of_same_length():
 
     assert result is not None
     # Which cycle is returned is not guaranteed.
-    assert are_same_circular_perm(result, ['M1', 'L1', 'M2', 'L2'])\
-        or are_same_circular_perm(result, ['M1', 'L2', 'M2', 'L3'])\
-        or are_same_circular_perm(result, ['M1', 'L3', 'M2', 'L1'])
+    assert are_same_circular_perm(
+        result, ['M1', 'L1', 'M2', 'L2'], consider_reverse=True)\
+        or are_same_circular_perm(
+            result, ['M1', 'L2', 'M2', 'L3'], consider_reverse=True)\
+        or are_same_circular_perm(
+            result, ['M1', 'L3', 'M2', 'L1'], consider_reverse=True)
 
 
 def test_multi_rings_of_different_length():
@@ -95,7 +100,8 @@ def test_multi_rings_of_different_length():
     result = find_shortest_cycle(M3L3_RING)
 
     assert result is not None
-    assert are_same_circular_perm(result, ['M1', 'L1', 'M2', 'L2'])
+    assert are_same_circular_perm(
+        result, ['M1', 'L1', 'M2', 'L2'], consider_reverse=True)
 
 
 def test_one_ring_and_one_parallel():
@@ -117,7 +123,8 @@ def test_one_ring_and_one_parallel():
     result = find_shortest_cycle(ML_PARALLEL_RING)
 
     assert result is not None
-    assert are_same_circular_perm(result, ['M1', 'L1'])
+    assert are_same_circular_perm(
+        result, ['M1', 'L1'], consider_reverse=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request updates the test cases in the `recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py` file to ensure that the `are_same_circular_perm` function considers reverse permutations. The most important changes include modifications to several test functions to include the `consider_reverse=True` parameter.

Updates to test cases:

* [`def test_one_ring()`](diffhunk://#diff-d26e523d87df7cf1ec7ff73d6e3a8f9d96e0fd14c09beecfcc16c8992833e4c2L28-R29): Modified the `are_same_circular_perm` assertion to include the `consider_reverse=True` parameter. (`recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py`)
* [`def test_one_parallel()`](diffhunk://#diff-d26e523d87df7cf1ec7ff73d6e3a8f9d96e0fd14c09beecfcc16c8992833e4c2L47-R49): Modified the `are_same_circular_perm` assertion to include the `consider_reverse=True` parameter. (`recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py`)
* [`def test_multi_rings_of_same_length()`](diffhunk://#diff-d26e523d87df7cf1ec7ff73d6e3a8f9d96e0fd14c09beecfcc16c8992833e4c2L70-R77): Modified the `are_same_circular_perm` assertions to include the `consider_reverse=True` parameter. (`recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py`)
* [`def test_multi_rings_of_different_length()`](diffhunk://#diff-d26e523d87df7cf1ec7ff73d6e3a8f9d96e0fd14c09beecfcc16c8992833e4c2L98-R104): Modified the `are_same_circular_perm` assertion to include the `consider_reverse=True` parameter. (`recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py`)
* [`def test_one_ring_and_one_parallel()`](diffhunk://#diff-d26e523d87df7cf1ec7ff73d6e3a8f9d96e0fd14c09beecfcc16c8992833e4c2L120-R127): Modified the `are_same_circular_perm` assertion to include the `consider_reverse=True` parameter. (`recsa/reaction_classification/utils/tests/test_shortest_cycle_search.py`)