### PR TITLE
Refactor save_assemblies_to_single_file to specify the type of assemblies

### DIFF
--- a/recsa/saving/assembly_multi_single_file.py
+++ b/recsa/saving/assembly_multi_single_file.py
@@ -16,7 +16,7 @@ add_assembly_representer()
 
 
 def save_assemblies_to_single_file(
-        assemblies: Iterable,
+        assemblies: Iterable[Assembly],
         output_file: str | Path,
         *,
         id_gen: Callable[[Assembly], str] | None = None,


### PR DESCRIPTION
This pull request includes a type annotation improvement to the `save_assemblies_to_single_file` function in the `recsa/saving/assembly_multi_single_file.py` file. The change specifies the type of elements within the `assemblies` iterable.

Type annotation improvement:

* [`recsa/saving/assembly_multi_single_file.py`](diffhunk://#diff-ef79b7eb35d3abee1019d1b2d4e6303847cdea2e3a8c402d8a851087aaec9cf0L19-R19): Added type annotation to specify that the `assemblies` parameter is an `Iterable` of `Assembly` objects