### PR TITLE
Refactor assembly_representer to rename yaml key

### DIFF
--- a/recsa/saving/representers/assembly.py
+++ b/recsa/saving/representers/assembly.py
@@ -9,7 +9,7 @@ __all__ = ['add_assembly_representer', 'assembly_representer']
 
 def assembly_representer(dumper, data: Assembly):
     assembly_dict = {
-        'component_id_to_kind': dict(data.comp_id_to_kind),
+        'comp_id_to_kind': dict(data.comp_id_to_kind),
         'bonds': [
             sorted([u, v]) for u, v 
             in sorted(data.bonds, key=lambda x: sorted(x))]


### PR DESCRIPTION
This pull request includes a small change to the `assembly_representer` function in the `recsa/saving/representers/assembly.py` file. The change rename a key in the dictionary being created.

* [`recsa/saving/representers/assembly.py`](diffhunk://#diff-315ba911f35d6acba66d35d0ac07ffd1c94d4c3f23bedf5bf7db6dacef6c3a6eL12-R12): Changed the key name from `'component_id_to_kind'` to `'comp_id_to_kind'` in the `assembly_representer` function.