### PR TITLE
Add test of save_assemblies_to_single_file with show_progress=False

### DIFF
--- a/recsa/saving/tests/test_assembly_multi_single_file.py
+++ b/recsa/saving/tests/test_assembly_multi_single_file.py
@@ -102,7 +102,7 @@ def test_overwrite(tmp_path):
     save_assemblies_to_single_file([], output_file, overwrite=True)
 
 
-def test_show_progress(capsys, tmp_path):
+def test_show_progress_true(capsys, tmp_path):
     assemblies = [Assembly({'M1': 'M', 'X1': 'X'}, [('M1.a', 'X1.a')])
                   for _ in range(3)]
     output_file = tmp_path / 'assemblies.yml'
@@ -117,6 +117,18 @@ def test_show_progress(capsys, tmp_path):
         'All assemblies saved successfully.\r?\n?'
     )
     assert re.match(expected_output, captured.out)
+
+
+def test_show_progress_false(capsys, tmp_path):
+    assemblies = [Assembly({'M1': 'M', 'X1': 'X'}, [('M1.a', 'X1.a')])
+                  for _ in range(3)]
+    output_file = tmp_path / 'assemblies.yml'
+
+    save_assemblies_to_single_file(assemblies, output_file, show_progress=False)
+
+    # No output should be printed
+    captured = capsys.readouterr()
+    assert captured.out == ''
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes updates to the test cases for saving assemblies in the `recsa/saving/tests/test_assembly_multi_single_file.py` file. The changes focus on improving the clarity of test case names and adding a new test case to cover additional functionality.

Test case improvements:

* Renamed the `test_show_progress` function to `test_show_progress_true` for better clarity. (`recsa/saving/tests/test_assembly_multi_single_file.py`)

New test case:

* Added a new test case named `test_show_progress_false` to verify that no output is printed when `show_progress` is set to `False`. (`recsa/saving/tests/test_assembly_multi_single_file.py`)