### PR TITLE
Add utility function for debugging, compare_bondsets_under_sym_ops

### DIFF
--- a/recsa/debug_utils/__init__.py
+++ b/recsa/debug_utils/__init__.py
@@ -1,0 +1,1 @@
+from .bondset_comparison import *

--- a/recsa/debug_utils/bondset_comparison.py
+++ b/recsa/debug_utils/bondset_comparison.py
@@ -1,0 +1,111 @@
+from collections.abc import Iterable, Mapping
+
+from recsa.bondset_enumeration import normalize_bondset_under_sym_ops
+
+
+def compare_bondsets_under_sym_ops(
+        bondsets1: Iterable[Iterable[str]],
+        bondsets2: Iterable[Iterable[str]],
+        sym_ops: Mapping[str, Mapping[str, str]] | None = None
+        ) -> tuple[set[frozenset[str]], set[frozenset[str]]]:
+    """Compare bondsets under symmetry operations.
+
+    The bondsets are compared by normalizing them under symmetry operations.
+    The normalized bondsets are the smallest bondsets among symmetry-equivalent bondsets.
+
+    Parameters
+    ----------
+    bondsets1 : Iterable[Iterable[str]]
+        First set of bondsets.
+    bondsets2 : Iterable[Iterable[str]]
+        Second set of bondsets.
+    sym_ops : Mapping[str, Mapping[str, str]], optional
+        Symmetry operations, by default None.
+
+    Returns
+    -------
+    tuple[set[frozenset[str]], set[frozenset[str]]]
+        Unique bondsets in the first and second sets, respectively.
+    """
+    _validate_bondsets(bondsets1)
+    _validate_bondsets(bondsets2)
+
+    normalized_to_orig_1 = _calc_normalized_to_orig_bondsets(
+        bondsets1, sym_ops)
+    normalized_to_orig_2 = _calc_normalized_to_orig_bondsets(
+        bondsets2, sym_ops)
+    
+    unique_1 = set()
+    unique_2 = set()
+
+    for normalized, orig in normalized_to_orig_1.items():
+        if normalized not in normalized_to_orig_2:
+            unique_1.add(orig)
+    for normalized, orig in normalized_to_orig_2.items():
+        if normalized not in normalized_to_orig_1:
+            unique_2.add(orig)
+    
+    return unique_1, unique_2
+
+
+def _validate_bondsets(
+        bondsets: Iterable[Iterable[str]]
+        ) -> None:
+    """Validate bondsets.
+
+    Check if bondsets contain duplicate bonds or duplicates among them.
+
+    Parameters
+    ----------
+    bondsets : Iterable[Iterable[str]]
+        Bondsets to validate.
+        
+    Raises
+    ------
+    RecsaValueError
+        If bondsets contain duplicate bonds or duplicates among them.
+    """
+    for bondset in bondsets:
+        if len(list(bondset)) > len(set(bondset)):
+            raise ValueError("Bondset contains duplicate bonds.")
+    bondsets = [frozenset(bondset) for bondset in bondsets]
+    if len(bondsets) > len(set(bondsets)):
+        raise ValueError("Bondsets contain duplicates.")
+
+
+def _calc_normalized_to_orig_bondsets(
+        bondsets: Iterable[Iterable[str]],
+        sym_ops: Mapping[str, Mapping[str, str]] | None = None
+        ) -> dict[frozenset[str], frozenset[str]]:
+    """Calculate normalized bondsets under symmetry operations.
+    
+    The normalized bondsets are the smallest bondsets among symmetry-equivalent bondsets.
+    
+    Parameters
+    ----------
+    bondsets : Iterable[Iterable[str]]
+        Bondsets to normalize.
+    sym_ops : Mapping[str, Mapping[str, str]], optional
+        Symmetry operations, by default None.
+
+    Returns
+    -------
+    dict[frozenset[str], frozenset[str]]
+        Mapping from normalized bondsets to original bondsets.
+    """
+    d = dict[frozenset[str], frozenset[str]]()
+    if sym_ops is None:
+        return {
+            frozenset(bondset): frozenset(bondset) 
+            for bondset in bondsets}
+    for bondset in bondsets:
+        bondset = set(bondset)
+        normalized = frozenset(
+            normalize_bondset_under_sym_ops(bondset, sym_ops))
+        if normalized in d:
+            raise ValueError(
+                f'Duplicate bondset found: '
+                f'{sorted(bondset)} and {sorted(d[normalized])}'
+                )
+        d[normalized] = frozenset(bondset)
+    return d

--- a/recsa/debug_utils/tests/test_bondset_comparison.py
+++ b/recsa/debug_utils/tests/test_bondset_comparison.py
@@ -1,0 +1,81 @@
+import pytest
+
+from recsa.debug_utils import compare_bondsets_under_sym_ops
+
+
+def test_same():
+    BONDSET1 = [['01']]
+    BONDSET2 = [['01']]
+    SYM_OPS = None
+    result = compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+    assert result == (set(), set())
+
+
+def test_same_under_sym_ops():
+    BONDSET1 = [['01']]
+    BONDSET2 = [['02']]
+    SYM_OPS = {'foo': {'01': '02', '02': '01'}}
+    result = compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+    assert result == (set(), set())
+
+
+def test_same_but_different_order():
+    BONDSET1 = [['01', '02']]
+    BONDSET2 = [['02', '01']]
+    SYM_OPS = None
+    result = compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+    assert result == (set(), set())
+
+
+def test_same_with_multiple_sym_ops():
+    BONDSET1 = [['01'], ['03']]
+    BONDSET2 = [['02'], ['04']]
+    SYM_OPS = {'foo': {'01': '02', '02': '01', '03': '03', '04': '04'},
+               'bar': {'01': '01', '02': '02', '03': '04', '04': '03'}}
+    # 02 is equivalent to 01 under 'foo' and 04 is equivalent to 03 under 'bar'.
+    result = compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+    assert result == (set(), set())
+
+
+def test_different():
+    BONDSET1 = [['01']]
+    BONDSET2 = [['02']]
+    SYM_OPS = None
+    result = compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+    assert result == ({frozenset({'01'})}, {frozenset({'02'})})
+
+
+def test_different_under_sym_ops():
+    BONDSET1 = [['01']]
+    BONDSET2 = [['03']]
+    SYM_OPS = {'foo': {'01': '02', '02': '01', '03': '03'}}
+    result = compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+    assert result == ({frozenset({'01'})}, {frozenset({'03'})})
+
+
+def test_duplicate_bond():
+    BONDSET1 = [['01', '01']]  # Duplicate bond.
+    BONDSET2 = [['02']]
+    SYM_OPS = None
+    with pytest.raises(ValueError):
+        compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+
+
+def test_duplicate_bondset():
+    BONDSET1 = [['01'], ['01']]  # Duplicate bondset.
+    BONDSET2 = [['01']]
+    SYM_OPS = None
+    with pytest.raises(ValueError):
+        compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+
+
+def test_duplicate_bondset_under_sym_ops():
+    BONDSET1 = [['01'], ['02']]  # Duplicate bondset under symmetry operations.
+    BONDSET2 = [['01']]
+    SYM_OPS = {'foo': {'01': '02', '02': '01'}}
+    with pytest.raises(ValueError):
+        compare_bondsets_under_sym_ops(BONDSET1, BONDSET2, SYM_OPS)
+
+
+if __name__ == '__main__':
+    pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request introduces a new utility for comparing bond sets under symmetry operations, along with corresponding tests. The main changes include the addition of a new function to compare bond sets and validation functions to ensure the bond sets are unique and properly formatted.

### New functionality for bond set comparison:

* [`recsa/debug_utils/bondset_comparison.py`](diffhunk://#diff-d43f60c519c8d0347e7d7c76593871e86183185dc24b7ebbd1c50b021ebbd3f5R1-R111): Added `compare_bondsets_under_sym_ops` function to compare bond sets under symmetry operations, including helper functions `_validate_bondsets` and `_calc_normalized_to_orig_bondsets` for validation and normalization.
* [`recsa/debug_utils/__init__.py`](diffhunk://#diff-98a66c0dc8e144ccf62904b19f6c372b59523d7cc2a0cb2c711826a3fdc10d68R1): Imported the new bond set comparison functionality.

### Tests for new functionality:

* [`recsa/debug_utils/tests/test_bondset_comparison.py`](diffhunk://#diff-6650a0e772fca09cf29fcc8d4b36b054f7ba6b12ffeec419ed3c20ed87797ae5R1-R81): Added tests to validate the `compare_bondsets_under_sym_ops` function, including cases for identical bond sets, bond sets equivalent under symmetry operations, and cases with duplicates.