### PR TITLE
Chore/update error msg in  validate bondsets

### DIFF
--- a/recsa/debug_utils/bondset_comparison.py
+++ b/recsa/debug_utils/bondset_comparison.py
@@ -137,7 +137,7 @@ def _calc_normalized_to_orig_bondsets(
             normalize_bondset_under_sym_ops(bondset, sym_ops))
         if normalized in d:
             raise ValueError(
-                f'Duplicate bondset found: '
+                f'Duplicate bondset under symmetry operations: '
                 f'{sorted(bondset)} and {sorted(d[normalized])}'
                 )
         d[normalized] = frozenset(bondset)


### PR DESCRIPTION
This pull request introduces several changes to the `recsa/debug_utils/bondset_comparison.py` file, focusing on improving bondset validation and duplicate detection. The most important changes include adding a new utility function to find duplicates and enhancing error messages for better clarity.

Enhancements to bondset validation and error handling:

* Added a new `_find_duplicates` function to detect duplicates in bondsets, improving the clarity and efficiency of duplicate detection.
* Enhanced error messages in `_validate_bondsets` to provide more detailed information about duplicate bonds and bondsets.
* Updated the error message in `_calc_normalized_to_orig_bondsets` to specify that the duplicate bondset was found under symmetry operations.

Code improvements:

* Imported `Hashable` and `TypeVar` to support the new `_find_duplicates` function.