### PR TITLE
Refactor bondset sorting functions and add function for sorting bonds

### DIFF
--- a/recsa/algorithms/__init__.py
+++ b/recsa/algorithms/__init__.py
@@ -20,6 +20,7 @@ from .assembly_equality import assemblies_equal
 from .assembly_separation import separate_product_if_possible
 from .aux_edge_existence import has_aux_edges
 from .bondset_sorting import sort_bondsets
+from .bondset_sorting import sort_bondsets_and_bonds
 from .hashing import calc_graph_hash_of_assembly
 from .isomorphic_assembly_search import find_isomorphic_assembly
 from .isomorphism import is_isomorphic

--- a/recsa/algorithms/bondset_sorting.py
+++ b/recsa/algorithms/bondset_sorting.py
@@ -1,21 +1,28 @@
+from collections.abc import Iterable
+from typing import TypeVar
+
 __all__ = ['sort_bondsets']
 
 
-def sort_bondsets(
-        bond_subsets: set[frozenset[str]]) -> list[set[str]]:
-    """Sort assemblies by the number of bonds and the bond IDs.
+T = TypeVar('T', bound=Iterable[str])
 
-    The number of bonds is the primary key, and the sorted tuple of
-    bond IDs is the secondary key.
 
-    Duplicate bond IDs may cause unexpected behavior.
+def sort_bondsets(bondsets: Iterable[T]) -> list[T]:
+    """Sort bondsets by the number of bonds and the sorted bond IDs.
 
-    # TODO: Add an example.
+    The number of bonds is the primary key, and the sorted bond IDs 
+    is the secondary key.
+
+    The order of the equal elements is preserved.
     """
     return sorted(
-        bond_subsets,  # type: ignore
-        # mypy states that the `sorted` function expects
-        # `Iterable[set[str]]`, but the reason is unclear.
+        bondsets,
+        key=lambda bondset: (len(list(bondset)), sorted(bondset))
+        )
 
-        key=lambda subset: (len(subset), sorted(subset))
+
+def sort_bondsets_and_bonds(bondsets: Iterable[Iterable[str]]) -> list[list[str]]:
+    """Sort bondsets and bonds in the bondsets."""
+    return sort_bondsets(
+        (sorted(bondset) for bondset in bondsets)
         )

--- a/recsa/algorithms/tests/test_bondset_sorting.py
+++ b/recsa/algorithms/tests/test_bondset_sorting.py
@@ -1,10 +1,53 @@
 import pytest
 
-from recsa.algorithms import sort_bondsets
+from recsa.algorithms import sort_bondsets, sort_bondsets_and_bonds
+
+# TODO: Add more test cases.
 
 
-def test_sort_bond_subsets():
-    pass
+def test_sort_bondsets():
+    BOND_SUBSETS = [
+        ['1', '3'],
+        ['2', '1'],
+        ['2', '3', '1'],
+        ['1', '2', '3'],
+        ['1'],
+        ['2'],
+    ]
+    EXPECTED = [
+        ['1'],
+        ['2'],
+        ['2', '1'],
+        ['1', '3'],
+        ['2', '3', '1'],
+        ['1', '2', '3'],
+    ]
+    # Notes:
+    # - ['2', '1'] < ['1', '3'] because they are sorted before comparison.
+    # - ['2', '3', '1'] < ['1', '2', '3'] because they are equal after sorting,
+    # and the order of the equal elements is preserved.
+    assert sort_bondsets(BOND_SUBSETS) == EXPECTED
+
+
+def test_sort_bondsets_and_bonds():
+    BOND_SUBSETS = [
+        ['1', '3'],
+        ['2', '1'],
+        ['2', '3', '1'],
+        ['1', '2', '3'],
+        ['1'],
+        ['2'],
+    ]
+    EXPECTED = [
+        ['1'],
+        ['2'],
+        ['1', '2'],
+        ['1', '3'],
+        ['1', '2', '3'],
+        ['1', '2', '3'],
+    ]
+    # Bonds in each bondset are also sorted.
+    assert sort_bondsets_and_bonds(BOND_SUBSETS) == EXPECTED
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes updates to the `recsa/algorithms` module, focusing on enhancing the bondset sorting functionality. The most important changes include the addition of a new sorting function, updates to the existing sorting function, and the introduction of new test cases.

Enhancements to bondset sorting functionality:

* [`recsa/algorithms/__init__.py`](diffhunk://#diff-9bb557ca9a38708a55fbfbd580b5e0afbb333ce024e4f591353905c9090199b2R23): Added import for the new `sort_bondsets_and_bonds` function.
* [`recsa/algorithms/bondset_sorting.py`](diffhunk://#diff-4d6031d0a37797787478f3da4b3730c24a22eee10bbbcd7329cd3c5fa47f8c33R1-R27): Introduced a new function `sort_bondsets_and_bonds` that sorts both bondsets and the bonds within each bondset. Additionally, modified the `sort_bondsets` function to use a more generic type and preserve the order of equal elements.

Introduction of new test cases:

* [`recsa/algorithms/tests/test_bondset_sorting.py`](diffhunk://#diff-174e6ba23a9ce0bf5c267df23f08459aa24b88e0be42ad7065c6e2c6aab0fa27L3-R50): Added test cases for both `sort_bondsets` and `sort_bondsets_and_bonds` functions to ensure correct functionality and order preservation