### PR TITLE
Refactor test_test_zero_padded_numbers to include reference to Issue #43

### DIFF
--- a/recsa/saving/tests/test_bondsets.py
+++ b/recsa/saving/tests/test_bondsets.py
@@ -88,27 +88,8 @@ def test_bondset_ordering_by_length(tmp_path):
 
 def test_test_zero_padded_numbers(tmp_path):
     # Test to ensure that zero-padded numbers are all quoted in the output
-    
-    # In YAML 1.1, scalars starting with a zero are resolved as 
-    # octal numbers if they only contain 0-7 unless they are quoted.
-    # So, in order to represent numbers like '08' and '09' as strings,
-    # they need to be quoted. This is why the PyYAML library quotes
-    # numbers like '01' and '07' when dumping them as strings.
-
-    # On the other hand, since numbers like '08' and '09' are not valid 
-    # octal numbers, PyYAML does not need to quote them. This is why
-    # PyYAML does not quote numbers like '08' and '09' when dumping them
-    # as strings.
-
-    # YAML 1.2 changed the rules for octal numbers, and now scalars starting
-    # with a zero are not resolved as octal numbers but as integers. This 
-    # means all scalars like '01', '07', '08', and '09' need to be quoted
-    # in order to represent them as strings.
-
-    # Since we prefer consistency in the output, we decided to use the
-    # CoreDumper from the yamlcore library, which implements the YAML 1.2 
-    # specification. As a result, all scalars starting with a zero are
-    # quoted in the output.
+    # See Issue #43 for detailed explanation:
+    # https://github.com/Hiraoka-Group/recsa/issues/43#issue-2630091131
 
     BONDSETS = {frozenset({'07', '08', '09', '10'})}
     EXPECTED_TEXT = "- ['07', '08', '09', '10']\n"


### PR DESCRIPTION
This pull request simplifies and clarifies the test documentation in the `recsa/saving/tests/test_bondsets.py` file by removing extensive comments and replacing them with a reference to a detailed issue explanation.

Changes to test documentation:

* [`recsa/saving/tests/test_bondsets.py`](diffhunk://#diff-abca32937d88490f64eec2ac38571998b9474f8f94b8ba9319d916e21901f671L91-R92): Removed detailed comments explaining the quoting of zero-padded numbers and replaced them with a reference to Issue #43 for a detailed explanation.