### PR TITLE
Adjust test module for load_bondsets to add test for dict input

### DIFF
--- a/recsa/loading/tests/test_bondsets.py
+++ b/recsa/loading/tests/test_bondsets.py
@@ -49,5 +49,12 @@ def test_convert_int_to_str(tmp_path):
     assert loaded == {0: {'1'}, 1: {'1', '2'}}
 
 
+def test_dict_data(tmp_path):
+    BONDSETS = {10: ['1'], 20: ['1', '2']}
+    bondsets_file = write_bondsets_to_file(tmp_path, BONDSETS)
+    loaded = load_bondsets(bondsets_file)
+    assert loaded == {10: {'1'}, 20: {'1', '2'}}
+
+
 if __name__ == '__main__':
     pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request adds a new test case to the `recsa/loading/tests/test_bondsets.py` file to ensure the correct loading of bondsets data from a dictionary.

* Added `test_dict_data` function to test loading bondsets from a dictionary.