### PR TITLE
Update default value of with_index param of save_assemblies to True

### DIFF
--- a/recsa/saving/assemblies.py
+++ b/recsa/saving/assemblies.py
@@ -16,7 +16,7 @@ def save_assemblies(
         *,
         overwrite: bool = False,
         show_progress: bool = True,
-        with_index: bool = False,
+        with_index: bool = True,
         ) -> None:
     """Save assemblies to a single YAML file."""
     output_file = Path(output_file)


### PR DESCRIPTION
This pull request includes a small change to the `recsa/saving/assemblies.py` file. The change modifies the default value of the `with_index` parameter in the `save_assemblies` function from `False` to `True`.

* [`recsa/saving/assemblies.py`](diffhunk://#diff-0346287c5854055044515bebc574712a39eed2d863bdc9f7fb353abe782e6f19L19-R19): Changed the default value of the `with_index` parameter in the `save_assemblies` function to `True`.