### PR TITLE
Add cap_bindsites_for_multi_assemblies

### DIFF
--- a/recsa/bindsite_capping/multi_assemblies.py
+++ b/recsa/bindsite_capping/multi_assemblies.py
@@ -1,0 +1,20 @@
+from collections.abc import Iterable, Iterator
+
+from recsa import Assembly, Component
+
+from .loading import CapParams
+from .multi_bindsites import cap_bindsites
+
+
+def cap_bindsites_for_multi_assemblies(
+        assemblies: Iterable[Assembly],
+        components: dict[str, Component],
+        cap_params: CapParams
+        ) -> Iterator[Assembly]:
+    for assembly in assemblies:
+        cap_bindsites(
+            assembly, components, 
+            cap_params.component_kind_to_be_capped,
+            cap_params.cap_component_kind, cap_params.cap_bindsite,
+            copy=False)
+        yield assembly


### PR DESCRIPTION
This pull request introduces a new function to handle capping of binding sites for multiple assemblies in the `recsa/bindsite_capping` module. The most important change is the addition of the `cap_bindsites_for_multi_assemblies` function.

New functionality:

* [`recsa/bindsite_capping/multi_assemblies.py`](diffhunk://#diff-8a47669d3cc06a872f676a47de0b58e08b142997f2514f90552eb4c2eaa5264eR1-R20): Added the `cap_bindsites_for_multi_assemblies` function to iterate over assemblies and apply the `cap_bindsites` function to each one.