### PR TITLE
Fix convert_bondset_to_assembly to use frozenset to make bonds hashable

### DIFF
--- a/recsa/bondset_to_assembly/single_assembly.py
+++ b/recsa/bondset_to_assembly/single_assembly.py
@@ -14,7 +14,7 @@ def convert_bondset_to_assembly(
     """Converts the connected bonds to a graph."""
     
     connected_bindsite_pairs = {
-        bond_id_to_bindsites[bond] for bond in bond_subset}
+        frozenset(bond_id_to_bindsites[bond]) for bond in bond_subset}
     
     template = Assembly(comp_id_to_kind, set(bond_id_to_bindsites.values()))
     


### PR DESCRIPTION
This pull request includes a small change to the `convert_bondset_to_assembly` function in the `recsa/bondset_to_assembly/single_assembly.py` file. The change involves modifying the way bond sites are stored in a set to ensure immutability.

* [`recsa/bondset_to_assembly/single_assembly.py`](diffhunk://#diff-1c65e3173848df104b9735f5c3d3c520f20bc5a47f60d4682abf87b93b94d5cdL17-R17): Fixed `connected_bindsite_pairs` to use `frozenset` instead of a list to be hashable.