### PR TITLE
Fix convert_bondset_to_assembly

### DIFF
--- a/recsa/bondset_to_assembly/single_assembly.py
+++ b/recsa/bondset_to_assembly/single_assembly.py
@@ -16,6 +16,6 @@ def convert_bondset_to_assembly(
     connected_bindsite_pairs = {
         frozenset(bond_id_to_bindsites[bond]) for bond in bond_subset}
     
-    template = Assembly(comp_id_to_kind, set(bond_id_to_bindsites.values()))
+    template = Assembly(comp_id_to_kind, bond_id_to_bindsites.values())
     
     return bond_induced_sub_assembly(template, connected_bindsite_pairs)


### PR DESCRIPTION
This pull request includes a small change to the `convert_bondset_to_assembly` function in the `recsa/bondset_to_assembly/single_assembly.py` file. The change simplifies the creation of the `template` variable by directly using `bond_id_to_bindsites.values()` instead of converting it to a set.

* [`recsa/bondset_to_assembly/single_assembly.py`](diffhunk://#diff-1c65e3173848df104b9735f5c3d3c520f20bc5a47f60d4682abf87b93b94d5cdL19-R19): Modified the `template` variable in the `convert_bondset_to_assembly` function to use `bond_id_to_bindsites.values()` directly.