### PR TITLE
Update find_unique_assemblies to remove assembly indexes from param and return

### DIFF
--- a/recsa/duplicate_exclusion/core.py
+++ b/recsa/duplicate_exclusion/core.py
@@ -9,9 +9,9 @@ __all__ = ['find_unique_assemblies']
 
 
 def find_unique_assemblies(
-        assemblies: Iterable[tuple[str, Assembly]],
+        assemblies: Iterable[Assembly],
         component_structures: Mapping[str, Component]
-        ) -> Iterator[tuple[str, Assembly]]:
+        ) -> Iterator[Assembly]:
     """Get unique assemblies.
 
     "Unique" here means that the assemblies are not isomorphic to each
@@ -40,9 +40,9 @@ def find_unique_assemblies(
     provided iterable is yielded as a unique assembly.
     """
     hash_to_uniques: dict[str, list[Assembly]] = defaultdict(list)
-    for id_, assembly in assemblies:
+    for assembly in assemblies:
         hash_ = calc_graph_hash_of_assembly(assembly, component_structures)
         if is_new(
                 hash_, assembly, hash_to_uniques, component_structures):
             hash_to_uniques[hash_].append(assembly)
-            yield id_, assembly
+            yield assembly


### PR DESCRIPTION
This pull request includes changes to the `find_unique_assemblies` function in the `recsa/duplicate_exclusion/core.py` file to simplify its parameters and return type.

Changes to function parameters and return type:

* [`recsa/duplicate_exclusion/core.py`](diffhunk://#diff-96ac26e052151978df137a86e503ae145be32f42dad3eb04d9b662f8e9465891L12-R14): Modified the `find_unique_assemblies` function to accept an `Iterable[Assembly]` instead of `Iterable[tuple[str, Assembly]]` and to return an `Iterator[Assembly]` instead of `Iterator[tuple[str, Assembly]]`.

Changes to function implementation:

* [`recsa/duplicate_exclusion/core.py`](diffhunk://#diff-96ac26e052151978df137a86e503ae145be32f42dad3eb04d9b662f8e9465891L43-R48): Updated the loop within `find_unique_assemblies` to iterate over `assemblies` directly and yield `assembly` instead of `id_, assembly`.