### PR TITLE
Add import for group_assemblies_by_isomorphism in recsa __init__

### DIFF
--- a/recsa/__init__.py
+++ b/recsa/__init__.py
@@ -44,6 +44,7 @@ from .bindsite_capping import cap_bindsites
 from .bindsite_capping import cap_single_bindsite
 
 from .duplicate_exclusion import find_unique_assemblies
+from .duplicate_exclusion import group_assemblies_by_isomorphism
 
 from .assembly_enumeration import enumerate_assemblies
 from .assembly_enumeration import enumerate_assemblies_pipeline


### PR DESCRIPTION
This pull request includes a small change to the `recsa/__init__.py` file. The change adds an import statement for the `group_assemblies_by_isomorphism` function to make it available in the module.

* [`recsa/__init__.py`](diffhunk://#diff-354bbb99c4bbbbcb56851a72800b67e864e019c31414b8df2d117293a333cd46R47): Added import statement for `group_assemblies_by_isomorphism` function.