### PR TITLE
Refactor reaction classes to include a 'to_dict' method

### DIFF
--- a/recsa/classes/reaction.py
+++ b/recsa/classes/reaction.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import ClassVar
 
 from .assembly import Assembly
@@ -18,6 +18,16 @@ class IntraReaction:
     entering_kind: str
     duplicate_count: int
 
+    def to_dict(self):
+        # This is a workaround to add the 'entering_assem_id' field 
+        # to the dictionary in the proper place (after 'init_assem_id').
+        d = {}
+        d_orig = asdict(self)
+        d['init_assem_id'] = d_orig['init_assem_id']
+        d['entering_assem_id'] = self.entering_assem_id
+        d.update(d_orig)
+        return d
+
 
 @dataclass
 class InterReaction:
@@ -32,6 +42,9 @@ class InterReaction:
     leaving_kind: str
     entering_kind: str
     duplicate_count: int
+
+    def to_dict(self):
+        return asdict(self)
 
 
 @dataclass


### PR DESCRIPTION
This pull request introduces new methods to convert class instances to dictionaries and includes a minor import change in the `recsa/classes/reaction.py` file. The most important changes include adding the `to_dict` method to the `IntraReaction` and `InterReaction` classes and updating the import statements to include `asdict`.

Enhancements to class functionality:

* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907R21-R30): Added `to_dict` method to `IntraReaction` class to include the `entering_assem_id` field in the dictionary representation.
* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907R46-R48): Added `to_dict` method to `InterReaction` class for converting instances to dictionaries.

Import updates:

* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907L1-R1): Updated import statements to include `asdict` from `dataclasses`.