### PR TITLE
Add reactions_to_df

### DIFF
--- a/recsa/__init__.py
+++ b/recsa/__init__.py
@@ -30,6 +30,7 @@ from .saving import save_components
 from .saving import save_reactions
 from .saving import save_reaction
 from .saving import save_assemblies
+from .saving import reactions_to_df
 
 # isort: split
 from .assembly_drawing import draw_2d

--- a/recsa/saving/__init__.py
+++ b/recsa/saving/__init__.py
@@ -3,5 +3,6 @@ from .bondset_txt import *
 from .bondsets import *
 from .components import *
 from .reaction import *
+from .reactions_df_conversion import *
 from .representers import *
 from .utils import *

--- a/recsa/saving/reactions_df_conversion.py
+++ b/recsa/saving/reactions_df_conversion.py
@@ -1,0 +1,12 @@
+from collections.abc import Iterable
+from typing import TypeAlias
+
+import pandas as pd
+
+from recsa import InterReaction, IntraReaction
+
+Reaction: TypeAlias = IntraReaction | InterReaction
+
+
+def reactions_to_df(reactions: Iterable[Reaction]) -> pd.DataFrame:
+    return pd.DataFrame([reaction.to_dict() for reaction in reactions])

--- a/recsa/saving/tests/test_reactions_df_conversion.py
+++ b/recsa/saving/tests/test_reactions_df_conversion.py
@@ -1,0 +1,40 @@
+import pytest
+
+from recsa import InterReaction, IntraReaction, reactions_to_df
+
+
+def test_basic():
+    reactions: list[IntraReaction | InterReaction] = [
+        IntraReaction(
+            'init1', 'prod1', 'leave1', 
+            'metal_bs1', 'leave_bs1', 'enter_bs1', 
+            'metal_kind1', 'leave_kind1', 'enter_kind1', 1),
+        InterReaction(
+            'init2', 'enter2', 'prod2', 'leave2',
+            'metal_bs2', 'leave_bs2', 'enter_bs2',
+            'metal_kind2', 'leave_kind2', 'enter_kind2', 2)
+    ]
+
+    df = reactions_to_df(reactions)
+
+    assert df.shape == (2, 11)
+    assert df.columns.tolist() == [
+        'init_assem_id', 'entering_assem_id', 'product_assem_id',
+        'leaving_assem_id', 'metal_bs', 'leaving_bs', 'entering_bs',
+        'metal_kind', 'leaving_kind', 'entering_kind', 'duplicate_count'
+    ]
+    assert df['init_assem_id'].tolist() == ['init1', 'init2']
+    assert df['entering_assem_id'].tolist() == [None, 'enter2']
+    assert df['product_assem_id'].tolist() == ['prod1', 'prod2']
+    assert df['leaving_assem_id'].tolist() == ['leave1', 'leave2']
+    assert df['metal_bs'].tolist() == ['metal_bs1', 'metal_bs2']
+    assert df['leaving_bs'].tolist() == ['leave_bs1', 'leave_bs2']
+    assert df['entering_bs'].tolist() == ['enter_bs1', 'enter_bs2']
+    assert df['metal_kind'].tolist() == ['metal_kind1', 'metal_kind2']
+    assert df['leaving_kind'].tolist() == ['leave_kind1', 'leave_kind2']
+    assert df['entering_kind'].tolist() == ['enter_kind1', 'enter_kind2']
+    assert df['duplicate_count'].tolist() == [1, 2]
+
+
+if __name__ == '__main__':
+    pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request introduces a new utility function to convert reaction objects into a pandas DataFrame and includes corresponding tests. The main changes involve importing the new function and adding the implementation and tests for it.

### New Functionality:
* Added `reactions_to_df` function to convert `InterReaction` and `IntraReaction` objects into a pandas DataFrame (`recsa/saving/reactions_df_conversion.py`).

### Import Statements:
* Imported `reactions_to_df` in `recsa/__init__.py`.
* Imported `reactions_df_conversion` module in `recsa/saving/__init__.py`.

### Testing:
* Added tests for `reactions_to_df` function in `recsa/saving/tests/test_reactions_df_conversion.py`.