### PR TITLE
Fix reactions_to_df to return df with correct dtypes

### DIFF
--- a/recsa/classes/reaction.py
+++ b/recsa/classes/reaction.py
@@ -19,13 +19,8 @@ class IntraReaction:
     duplicate_count: int
 
     def to_dict(self):
-        # This is a workaround to add the 'entering_assem_id' field 
-        # to the dictionary in the proper place (after 'init_assem_id').
-        d = {}
-        d_orig = asdict(self)
-        d['init_assem_id'] = d_orig['init_assem_id']
+        d = asdict(self)
         d['entering_assem_id'] = self.entering_assem_id
-        d.update(d_orig)
         return d
 
 

--- a/recsa/saving/reactions_df_conversion.py
+++ b/recsa/saving/reactions_df_conversion.py
@@ -9,4 +9,19 @@ Reaction: TypeAlias = IntraReaction | InterReaction
 
 
 def reactions_to_df(reactions: Iterable[Reaction]) -> pd.DataFrame:
-    return pd.DataFrame([reaction.to_dict() for reaction in reactions])
+    df = pd.DataFrame(
+        [reaction.to_dict() for reaction in reactions],
+        columns=[
+            'init_assem_id', 'entering_assem_id', 
+            'product_assem_id', 'leaving_assem_id', 
+            'metal_bs', 'leaving_bs', 'entering_bs', 
+            'metal_kind', 'leaving_kind', 'entering_kind', 
+            'duplicate_count', 
+        ]
+    )
+    if isinstance(next(iter(reactions)).init_assem_id, int):
+        return df.astype({
+            'init_assem_id': int, 'entering_assem_id': pd.Int64Dtype(), 
+            'product_assem_id': int, 'leaving_assem_id': pd.Int64Dtype()
+        })
+    return df

--- a/recsa/saving/tests/test_reactions_df_conversion.py
+++ b/recsa/saving/tests/test_reactions_df_conversion.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from recsa import InterReaction, IntraReaction, reactions_to_df
@@ -6,11 +7,11 @@ from recsa import InterReaction, IntraReaction, reactions_to_df
 def test_basic():
     reactions: list[IntraReaction | InterReaction] = [
         IntraReaction(
-            'init1', 'prod1', 'leave1', 
+            0, 1, 2, 
             'metal_bs1', 'leave_bs1', 'enter_bs1', 
             'metal_kind1', 'leave_kind1', 'enter_kind1', 1),
         InterReaction(
-            'init2', 'enter2', 'prod2', 'leave2',
+            3, 4, 5, None,
             'metal_bs2', 'leave_bs2', 'enter_bs2',
             'metal_kind2', 'leave_kind2', 'enter_kind2', 2)
     ]
@@ -23,10 +24,10 @@ def test_basic():
         'leaving_assem_id', 'metal_bs', 'leaving_bs', 'entering_bs',
         'metal_kind', 'leaving_kind', 'entering_kind', 'duplicate_count'
     ]
-    assert df['init_assem_id'].tolist() == ['init1', 'init2']
-    assert df['entering_assem_id'].tolist() == [None, 'enter2']
-    assert df['product_assem_id'].tolist() == ['prod1', 'prod2']
-    assert df['leaving_assem_id'].tolist() == ['leave1', 'leave2']
+    assert df['init_assem_id'].tolist() == [0, 3]
+    assert df['entering_assem_id'].tolist() == [pd.NA, 4]
+    assert df['product_assem_id'].tolist() == [1, 5]
+    assert df['leaving_assem_id'].tolist() == [2, pd.NA]
     assert df['metal_bs'].tolist() == ['metal_bs1', 'metal_bs2']
     assert df['leaving_bs'].tolist() == ['leave_bs1', 'leave_bs2']
     assert df['entering_bs'].tolist() == ['enter_bs1', 'enter_bs2']


### PR DESCRIPTION
This pull request includes several updates to the handling and testing of reaction data in the `recsa` module. The key changes involve simplifying the `to_dict` method, ensuring proper DataFrame construction, and updating tests to reflect these changes.

### Improvements to reaction data handling:

* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907L22-L28): Simplified the `to_dict` method in the `IntraReaction` class by removing the workaround for adding the `entering_assem_id` field.
* [`recsa/saving/reactions_df_conversion.py`](diffhunk://#diff-a4365f000187713d1ba76b0e9ed0d20e279a36e660609859fb5ac6ae6029fc42L12-R27): Enhanced the `reactions_to_df` function to explicitly define DataFrame columns and ensure correct data types for integer fields.

### Updates to tests:

* [`recsa/saving/tests/test_reactions_df_conversion.py`](diffhunk://#diff-c59cabe85f1eea87af028577d00c700797b7bd0b95bc591aa5d62d9720bbd3a8R1): Added `pandas` import for testing.
* [`recsa/saving/tests/test_reactions_df_conversion.py`](diffhunk://#diff-c59cabe85f1eea87af028577d00c700797b7bd0b95bc591aa5d62d9720bbd3a8L9-R14): Updated the `test_basic` function to use integer values for `init_assem_id`, `product_assem_id`, and `leaving_assem_id` fields.
* [`recsa/saving/tests/test_reactions_df_conversion.py`](diffhunk://#diff-c59cabe85f1eea87af028577d00c700797b7bd0b95bc591aa5d62d9720bbd3a8L26-R30): Adjusted assertions in `test_basic` to match the new integer-based field values and handle `pd.NA` for missing values.