### PR TITLE
Refactor reaction classes to accept and int as assembly IDs

### DIFF
--- a/recsa/classes/reaction.py
+++ b/recsa/classes/reaction.py
@@ -6,10 +6,10 @@ from .assembly import Assembly
 
 @dataclass
 class IntraReaction:
-    init_assem_id: str
+    init_assem_id: str | int
     entering_assem_id: ClassVar[None] = None
-    product_assem_id: str
-    leaving_assem_id: str | None
+    product_assem_id: str | int
+    leaving_assem_id: str | int | None
     metal_bs: str
     leaving_bs: str
     entering_bs: str
@@ -26,10 +26,10 @@ class IntraReaction:
 
 @dataclass
 class InterReaction:
-    init_assem_id: str
-    entering_assem_id: str
-    product_assem_id: str
-    leaving_assem_id: str | None
+    init_assem_id: str | int
+    entering_assem_id: str | int
+    product_assem_id: str | int
+    leaving_assem_id: str | int | None
     metal_bs: str
     leaving_bs: str
     entering_bs: str


### PR DESCRIPTION
This pull request includes changes to the `recsa/classes/reaction.py` file to allow for more flexible data types for certain class attributes. The most important changes include updating the data types of several attributes in the `IntraReaction` and `InterReaction` classes.

Changes to attribute data types:

* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907L9-R12): Updated `init_assem_id`, `product_assem_id`, and `leaving_assem_id` attributes in the `IntraReaction` class to accept both `str` and `int` types.
* [`recsa/classes/reaction.py`](diffhunk://#diff-4d9c6faa3816b60c5988161954e483c6559da2cf0290072ad51e511bd5565907L29-R32): Updated `init_assem_id`, `entering_assem_id`, `product_assem_id`, and `leaving_assem_id` attributes in the `InterReaction` class to accept both `str` and `int` types.