### PR TITLE
Add CI workflow for pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,37 @@
+name: Python package test
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run tests
+        run: poetry run pytest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the testing of the Python package. The workflow is configured to run tests on specific branches using Poetry for dependency management.

New GitHub Actions workflow:

* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aR1-R37): Added a workflow named "Python package test" that triggers on pushes and pull requests to the `main` and `develop` branches. It runs tests using Python 3.12 on an Ubuntu environment, sets up Python, installs Poetry, installs dependencies, and runs tests with `pytest`.