### PR TITLE
Update functions to accept integer assembly IDs

### DIFF
--- a/recsa/algorithms/isomorphic_assembly_search.py
+++ b/recsa/algorithms/isomorphic_assembly_search.py
@@ -7,10 +7,10 @@ from recsa.algorithms.isomorphism import is_isomorphic
 
 def find_isomorphic_assembly(
         target_assembly: Assembly,
-        id_to_assembly: Mapping[str, Assembly],
-        hash_to_ids: Mapping[str, Iterable[str]],
+        id_to_assembly: Mapping[str | int, Assembly],
+        hash_to_ids: Mapping[str, Iterable[str | int]],
         component_structures: Mapping[str, Component]
-        ) -> str | None:
+        ) -> str | int | None:
     # TODO: Reduce the number of calls to calc_wl_hash_of_assembly.
     # Maybe we can use the numbers of each component kind in the assembly.
     hash_ = calc_graph_hash_of_assembly(target_assembly, component_structures)

--- a/recsa/algorithms/reaction_embedding.py
+++ b/recsa/algorithms/reaction_embedding.py
@@ -7,16 +7,16 @@ from recsa import (Assembly, InterReaction, InterReactionEmbedded,
 @overload
 def embed_assemblies_into_reaction(
     reaction: IntraReaction,
-    id_to_assembly: dict[str, Assembly]
+    id_to_assembly: dict[str | int, Assembly]
     ) -> IntraReactionEmbedded: ...
 @overload
 def embed_assemblies_into_reaction(
     reaction: InterReaction,
-    id_to_assembly: dict[str, Assembly]
+    id_to_assembly: dict[str | int, Assembly]
     ) -> InterReactionEmbedded: ...
 def embed_assemblies_into_reaction(
         reaction: IntraReaction | InterReaction,
-        id_to_assembly: dict[str, Assembly]):
+        id_to_assembly: dict[str | int, Assembly]):
     """Embed the assemblies into the reaction."""
     init_assem = id_to_assembly[reaction.init_assem_id]
     product_assem = id_to_assembly[reaction.product_assem_id]

--- a/recsa/duplicate_exclusion/detailed.py
+++ b/recsa/duplicate_exclusion/detailed.py
@@ -8,9 +8,10 @@ __all__ = ['exclude_remaining_duplicates']
 
 
 def exclude_remaining_duplicates(
-        id_to_assembly: Mapping[str, Assembly],
+        id_to_assembly: Mapping[str | int, Assembly],
         component_structures: Mapping[str, Component],
-        ) -> tuple[dict[str, Assembly], dict[str, set[str]]]:
+        ) -> tuple[dict[str | int, Assembly], 
+                   dict[str | int, set[str | int]]]:
     """Exclude remaining duplicates."""
     unique_id_to_ids = group_assemblies_by_isomorphism(id_to_assembly, component_structures)
     unique_ids = unique_id_to_ids.keys()

--- a/recsa/duplicate_exclusion/lib/grouping_by_hash.py
+++ b/recsa/duplicate_exclusion/lib/grouping_by_hash.py
@@ -1,18 +1,16 @@
 from collections import defaultdict
-from collections.abc import Hashable, Mapping
-from typing import TypeVar
+from collections.abc import Mapping
 
 from recsa import Assembly, Component, calc_graph_hash_of_assembly
 
 __all__ = ['group_assemblies_by_hash']
 
-T = TypeVar('T', bound=Hashable)
 
 
 def group_assemblies_by_hash(
-        id_to_assembly: Mapping[T, Assembly],
+        id_to_assembly: Mapping[str | int, Assembly],
         component_structures: Mapping[str, Component]
-        ) -> dict[str, set[T]]:
+        ) -> dict[str, set[str | int]]:
     # Group by hash
     hash_to_ids = defaultdict(set)
     for id_, assembly in id_to_assembly.items():

--- a/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
+++ b/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
@@ -1,6 +1,5 @@
-from collections.abc import Hashable, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from itertools import combinations
-from typing import TypeVar
 
 from networkx.utils import UnionFind
 
@@ -10,13 +9,12 @@ from .grouping_by_hash import group_assemblies_by_hash
 
 __all__ = ['group_assemblies_by_isomorphism']
 
-T = TypeVar('T', bound=Hashable)
 
 
 def group_assemblies_by_isomorphism(
-        id_to_assembly: Mapping[T, Assembly],
+        id_to_assembly: Mapping[str | int, Assembly],
         component_structures: Mapping[str, Component]
-        ) -> dict[T, set[T]]:
+        ) -> dict[str | int, set[str | int]]:
     """Group duplicates by assembly isomorphism.
 
     Parameters
@@ -49,6 +47,6 @@ def group_assemblies_by_isomorphism(
                     component_structures):
                 uf.union(id1, id2)
 
-    grouped_ids: Iterable[set[T]] = uf.to_sets()
+    grouped_ids: Iterable[set[str | int]] = uf.to_sets()
     unique_id_to_ids = {min(ids): ids for ids in grouped_ids}
     return unique_id_to_ids

--- a/recsa/reaction_exploration/core.py
+++ b/recsa/reaction_exploration/core.py
@@ -11,7 +11,7 @@ from .intra import explore_intra_reactions
 
 
 def explore_reactions(
-        id_to_assembly: Mapping[str, Assembly],
+        id_to_assembly: Mapping[str | int, Assembly],
         metal_kind: str, leaving_kind: str, entering_kind: str,
         component_structures: Mapping[str, Component],
         ) -> Iterator[IntraReaction | InterReaction]:

--- a/recsa/reaction_exploration/inter.py
+++ b/recsa/reaction_exploration/inter.py
@@ -12,10 +12,10 @@ __all__ = ['explore_inter_reactions']
 
 
 def explore_inter_reactions(
-        init_assem_id: str, entering_assem_id: str,
+        init_assem_id: str | int, entering_assem_id: str | int,
         metal_kind: str, leaving_kind: str, entering_kind: str,
-        id_to_assembly: Mapping[str, Assembly],
-        hash_to_ids: Mapping[str, Iterable[str]],
+        id_to_assembly: Mapping[str | int, Assembly],
+        hash_to_ids: Mapping[str, Iterable[str | int]],
         component_structures: Mapping[str, Component],
         ) -> Iterator[InterReaction]:
     init_assem = id_to_assembly[init_assem_id]
@@ -55,7 +55,6 @@ def explore_inter_reactions(
             yield InterReaction(
                 init_assem_id, entering_assem_id, product_id,
                 None, metal_bs, leaving_bs, entering_bs,
-                metal_kind, leaving_kind, entering_kind,
                 duplicate_count)
             continue
 
@@ -68,5 +67,4 @@ def explore_inter_reactions(
         yield InterReaction(
             init_assem_id, entering_assem_id, product_id, leaving_id,
             metal_bs, leaving_bs, entering_bs,
-            metal_kind, leaving_kind, entering_kind,
             duplicate_count)

--- a/recsa/reaction_exploration/intra.py
+++ b/recsa/reaction_exploration/intra.py
@@ -9,10 +9,10 @@ from .lib import (compute_unique_bindsites_or_bindsite_sets,
 
 
 def explore_intra_reactions(
-        init_assem_id: str,
+        init_assem_id: str | int,
         metal_kind: str, leaving_kind: str, entering_kind: str,
-        id_to_assembly: Mapping[str, Assembly],
-        hash_to_ids: Mapping[str, Iterable[str]],
+        id_to_assembly: Mapping[str | int, Assembly],
+        hash_to_ids: Mapping[str, Iterable[str | int]],
         component_structures: Mapping[str, Component],
         ) -> Iterator[IntraReaction]:
     init_assem = id_to_assembly[init_assem_id]
@@ -39,8 +39,7 @@ def explore_intra_reactions(
         if leaving is None:
             yield IntraReaction(
                 init_assem_id, product_id, None,
-                metal_bs, leaving_bs, entering_bs, metal_kind,
-                leaving_kind, entering_kind,
+                metal_bs, leaving_bs, entering_bs, 
                 duplicate_count)
             continue
 
@@ -52,7 +51,5 @@ def explore_intra_reactions(
 
         yield IntraReaction(
             init_assem_id, product_id, leaving_id,
-            metal_bs, leaving_bs,
-            entering_bs, metal_kind,
-            leaving_kind, entering_kind,
+            metal_bs, leaving_bs, entering_bs, 
             duplicate_count)

--- a/recsa/reaction_exploration/lib/entering_bindsite_enumeration.py
+++ b/recsa/reaction_exploration/lib/entering_bindsite_enumeration.py
@@ -9,7 +9,7 @@ __all__ = ['enum_valid_entering_bindsites']
 
 
 def _cache_key2(
-        assembly_id: str,
+        assembly_id: str | int,
         assembly: Assembly,
         entering_kind: str,
         component_structures: Mapping[str, Component],
@@ -19,7 +19,7 @@ def _cache_key2(
 
 @cached(cache={}, key=_cache_key2)
 def enum_valid_entering_bindsites(
-        assembly_id: str,  # only used for caching
+        assembly_id: str | int,  # only used for caching
         assembly: Assembly,
         entering_kind: str,
         component_structures: Mapping[str, Component],

--- a/recsa/reaction_exploration/lib/ml_pair_enumeration.py
+++ b/recsa/reaction_exploration/lib/ml_pair_enumeration.py
@@ -9,7 +9,7 @@ __all__ = ['enum_valid_ml_pairs']
 
 
 def _cache_key(
-        assembly_id: str,
+        assembly_id: str | int,
         assembly: Assembly,
         metal_kind: str, leaving_kind: str,
         component_structures: Mapping[str, Component]
@@ -19,7 +19,7 @@ def _cache_key(
 
 @cached(cache={}, key=_cache_key)
 def enum_valid_ml_pairs(
-        assembly_id: str,  # only used for caching
+        assembly_id: str | int,  # only used for caching
         assembly: Assembly,
         metal_kind: str, leaving_kind: str,
         component_structures: Mapping[str, Component]

--- a/recsa/reaction_exploration/lib/mle_enumeration_for_intra.py
+++ b/recsa/reaction_exploration/lib/mle_enumeration_for_intra.py
@@ -10,7 +10,7 @@ __all__ = ['enum_valid_mles_for_intra']
 
 
 def _cache_key(
-        assembly_id: str,
+        assembly_id: str | int,
         assembly: Assembly,
         metal_kind: str, leaving_kind: str, entering_kind: str,
         component_structures: Mapping[str, Component],
@@ -20,7 +20,7 @@ def _cache_key(
 
 @cached(cache={}, key=_cache_key)
 def enum_valid_mles_for_intra(
-        assembly_id: str,  # only used for caching
+        assembly_id: str | int,  # only used for caching
         assembly: Assembly,
         metal_kind: str, leaving_kind: str, entering_kind: str,
         component_structures: Mapping[str, Component],

--- a/recsa/reaction_exploration/lib/unique_bindsite_or_bindsite_sets.py
+++ b/recsa/reaction_exploration/lib/unique_bindsite_or_bindsite_sets.py
@@ -14,7 +14,7 @@ __all__ = ['compute_unique_bindsites_or_bindsite_sets']
 
 
 def _cache_key(
-        assembly_id: str,
+        assembly_id: str | int,
         assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[str] | Iterable[tuple[str, ...]],
         component_structures: Mapping[str, Component],
@@ -24,25 +24,25 @@ def _cache_key(
 
 @overload
 def compute_unique_bindsites_or_bindsite_sets(
-        assembly_id: str, assembly: Assembly,
+        assembly_id: str | int, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[str],
         component_structures: Mapping[str, Component],
         ) -> list[tuple[str, int]]: ...
 @overload
 def compute_unique_bindsites_or_bindsite_sets(
-        assembly_id: str, assembly: Assembly,
+        assembly_id: str | int, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[tuple[str, str]],
         component_structures: Mapping[str, Component],
         ) -> list[tuple[tuple[str, str], int]]: ...
 @overload
 def compute_unique_bindsites_or_bindsite_sets(
-        assembly_id: str, assembly: Assembly,
+        assembly_id: str | int, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[tuple[str, str, str]],
         component_structures: Mapping[str, Component],
         ) -> list[tuple[tuple[str, str, str], int]]: ...
 @overload
 def compute_unique_bindsites_or_bindsite_sets(
-        assembly_id: str, assembly: Assembly,
+        assembly_id: str | int, assembly: Assembly,
         bindsites_or_bindsite_sets: Iterable[tuple[str, ...]],
         component_structures: Mapping[str, Component],
         ) -> list[tuple[tuple[str, ...], int]]: ...


### PR DESCRIPTION
This pull request includes changes to support both string and integer types for assembly identifiers across various modules. The most important changes include updating type annotations, modifying function signatures, and removing unnecessary type variables.

### Type Annotation Updates:
* [`recsa/algorithms/isomorphic_assembly_search.py`](diffhunk://#diff-5fab26d246ed337281626274b3af269937b3691cd2cc6583f41f47724eaa0131L10-R13): Updated type annotations to support `str | int` for assembly identifiers.
* [`recsa/algorithms/reaction_embedding.py`](diffhunk://#diff-b18b9b819a762a41e2f12edd644634dbba13117c12dfd613ed22e901e3fa4728L10-R19): Changed `id_to_assembly` parameter to accept `dict[str | int, Assembly]`.
* [`recsa/duplicate_exclusion/detailed.py`](diffhunk://#diff-6329d198b00de1340027a92d136a994d0f89f98e924fbd1a0a596d4fdb230a6cL11-R14): Modified type annotations to support `str | int` for assembly identifiers.
* `recsa/reaction_exploration/core.py`, `recsa/reaction_exploration/inter.py`, `recsa/reaction_exploration/intra.py`: Updated type annotations for assembly identifiers in various functions. [[1]](diffhunk://#diff-ee7c64af70bc2b141ce4b37b2be5a53c55846eda0ad1e24f56e7e6624805bf60L14-R14) [[2]](diffhunk://#diff-d17317231781e02df4ef57bc7070870ccc3647c9bc46f17e0ccb1c512f5bd745L15-R18) [[3]](diffhunk://#diff-e99315720358a21f1acb8c083b9d6164e5a581408c27b28d67e061c8e09b6db6L12-R15)

### Function Signature Modifications:
* `recsa/reaction_exploration/lib/entering_bindsite_enumeration.py`, `recsa/reaction_exploration/lib/ml_pair_enumeration.py`, `recsa/reaction_exploration/lib/mle_enumeration_for_intra.py`, `recsa/reaction_exploration/lib/unique_bindsite_or_bindsite_sets.py`: Adjusted function signatures to accept `str | int` for assembly identifiers. [[1]](diffhunk://#diff-50f87112986354be552f7b7202c2949d259fa1bd7eccc1f5b55d17219df5cee9L12-R12) [[2]](diffhunk://#diff-dd64397ac443039b9e7c45b730fe467ffc98d13cda7b64b096850331c66a2597L12-R12) [[3]](diffhunk://#diff-f559450e7054111e4d060e1016dd8d7ac19ecd1843cc918696aec151bd8f0cb5L13-R13) [[4]](diffhunk://#diff-c034033e90c67fb7dc5675b6a56751aa73231c9b42fda31f6cb57cc3c7672e17L17-R17)

### Removal of Unnecessary Type Variables:
* `recsa/duplicate_exclusion/lib/grouping_by_hash.py`, `recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py`: Removed unnecessary type variables and updated type annotations to support `str | int`. [[1]](diffhunk://#diff-2b76f15e941146629cca52e6075727944cf21f29f6405917b5c87ba6bd9e9f35L2-R13) [[2]](diffhunk://#diff-6c306c0edfdba6044ef7409251f3becdc5a27ad62a4a2d63a0ccd6526bc9f638L1-L3) [[3]](diffhunk://#diff-6c306c0edfdba6044ef7409251f3becdc5a27ad62a4a2d63a0ccd6526bc9f638L13-R17) [[4]](diffhunk://#diff-6c306c0edfdba6044ef7409251f3becdc5a27ad62a4a2d63a0ccd6526bc9f638L52-R50)

### Cleanup:
* Removed redundant type annotations in `explore_inter_reactions` and `explore_intra_reactions` functions. [[1]](diffhunk://#diff-d17317231781e02df4ef57bc7070870ccc3647c9bc46f17e0ccb1c512f5bd745L58) [[2]](diffhunk://#diff-d17317231781e02df4ef57bc7070870ccc3647c9bc46f17e0ccb1c512f5bd745L71) [[3]](diffhunk://#diff-e99315720358a21f1acb8c083b9d6164e5a581408c27b28d67e061c8e09b6db6L42-R42) [[4]](diffhunk://#diff-e99315720358a21f1acb8c083b9d6164e5a581408c27b28d67e061c8e09b6db6L55-R54)