### PR TITLE
Update bondset functions to use integer types for IDs

### DIFF
--- a/recsa/bondset_enumeration/core.py
+++ b/recsa/bondset_enumeration/core.py
@@ -8,10 +8,10 @@ __all__ = ['enum_bond_subsets']
 
 
 def enum_bond_subsets(
-        bonds: Iterable[str],
-        bond_to_adj_bonds: Mapping[str, Iterable[str]], 
-        sym_ops: Mapping[str, Mapping[str, str]] | None = None
-        ) -> set[frozenset[str]]:
+        bonds: Iterable[int],
+        bond_to_adj_bonds: Mapping[int, Iterable[int]], 
+        sym_ops: Mapping[str, Mapping[int, int]] | None = None
+        ) -> set[frozenset[int]]:
     """Enumerate connected subsets of bonds excluding symmetry-equivalent ones.
 
     When an assembly is represented as a set of bonds, subsets of 
@@ -44,15 +44,15 @@ def enum_bond_subsets(
 
     Parameters
     ----------
-    bonds : Iterable[BondId]
-        An iterable of bond IDs. Bond IDs can be strings or integers.
+    bonds : Iterable[int]
+        An iterable of bond IDs.
         The resulting bondsets are dependent on the order of the bonds.
-    bond_to_adj_bonds : Mapping[BondId, Iterable[BondId]]
+    bond_to_adj_bonds : Mapping[int, Iterable[int]]
         A dictionary mapping a bond to its adjacent bonds.
         Each key is the ID of a bond, and its value is an iterable
         of IDs of adjacent bonds.
         This dictionary is used for connectivity check.
-    sym_ops : Mapping[str, Mapping[BondId, BondId]] | None, optional
+    sym_ops : Mapping[str, Mapping[int, int]] | None, optional
         A dictionary of symmetry operations.
         Each key is the name of a symmetry operation, and its value is
         a mapping of bond IDs to their images under the symmetry operation.
@@ -64,14 +64,9 @@ def enum_bond_subsets(
 
     Returns
     -------
-    set[frozenset[BondId]]
+    set[frozenset[int]]
         A set of connected subsets of bonds excluding symmetry-equivalent
         ones. Each subset is represented as a frozenset of bond IDs.
-
-    Type Variables
-    --------------
-    BondId : str | int
-        Type of bond names.
 
     Notes
     -----
@@ -119,7 +114,7 @@ def enum_bond_subsets(
     >>> recsa.enum_bond_subsets(BONDS, BOND_TO_ADJ_BONDS, SYM_OPS)
     {frozenset({1}), frozenset({1, 2}), frozenset({1, 2, 3})}
     """
-    found: set[frozenset[str]] = set()
+    found: set[frozenset[int]] = set()
 
     single_bond_subsets = enum_single_bond_subsets(bonds, sym_ops)
     found.update(single_bond_subsets)

--- a/recsa/bondset_enumeration/lib/is_new_check.py
+++ b/recsa/bondset_enumeration/lib/is_new_check.py
@@ -6,9 +6,9 @@ __all__ = ['is_new_under_symmetry']
 
 
 def is_new_under_symmetry(
-        found_assems: set[frozenset[str]],
-        new_assem: set[str],
-        sym_ops: Mapping[str, Mapping[str, str]] | None = None
+        found_assems: set[frozenset[int]],
+        new_assem: set[int],
+        sym_ops: Mapping[str, Mapping[int, int]] | None = None
         ) -> bool:
     """Check if a new assembly is not symmetry-equivalent to the found ones.
 

--- a/recsa/bondset_enumeration/lib/multi_bond.py
+++ b/recsa/bondset_enumeration/lib/multi_bond.py
@@ -8,10 +8,10 @@ __all__ = ['enum_multi_bond_subsets']
 
 
 def enum_multi_bond_subsets(
-        prev_assems: set[frozenset[str]],
-        bond_to_adj_bonds: Mapping[str, Iterable[str]],
-        sym_ops: Mapping[str, Mapping[str, str]] | None = None
-        ) -> set[frozenset[str]]:
+        prev_assems: set[frozenset[int]],
+        bond_to_adj_bonds: Mapping[int, Iterable[int]],
+        sym_ops: Mapping[str, Mapping[int, int]] | None = None
+        ) -> set[frozenset[int]]:
     """Enumerate multi-bond subsets of bonds
     excluding disconnected ones and symmetry-equivalent ones.
     """
@@ -19,13 +19,13 @@ def enum_multi_bond_subsets(
         bond: set(adj_bonds) 
         for bond, adj_bonds in bond_to_adj_bonds.items()}
     
-    found: set[frozenset[str]] = set()
+    found: set[frozenset[int]] = set()
 
     # NOTE: The order of the iteration should be fixed to make the 
     # result deterministic.
     for prev in sort_bondsets(prev_assems):
         # List adjacent bonds to the bonds in the previous assembly.
-        adj_bonds: set[str] = set()
+        adj_bonds: set[int] = set()
         for bond in prev:
             adj_bonds.update(bond_to_adj_bonds[bond])
         # Bonds in the previous assembly should be excluded.

--- a/recsa/bondset_enumeration/lib/normalization.py
+++ b/recsa/bondset_enumeration/lib/normalization.py
@@ -6,9 +6,9 @@ __all__ = ['normalize_bondset_under_sym_ops']
 
 
 def normalize_bondset_under_sym_ops(
-        bondset: Iterable[str],
-        sym_ops: Mapping[str, Mapping[str, str]] | None = None
-        ) -> set[str]:
+        bondset: Iterable[int],
+        sym_ops: Mapping[str, Mapping[int, int]] | None = None
+        ) -> set[int]:
     """Find a representative of an assembly under symmetry operations.
 
     There can be multiple symmetry-equivalent assemblies for a given

--- a/recsa/bondset_enumeration/lib/single_bond.py
+++ b/recsa/bondset_enumeration/lib/single_bond.py
@@ -6,13 +6,13 @@ __all__ = ['enum_single_bond_subsets']
 
 
 def enum_single_bond_subsets(
-        bonds: Iterable[str],
-        sym_ops: Mapping[str, Mapping[str, str]] | None = None
-        ) -> set[frozenset[str]]:
+        bonds: Iterable[int],
+        sym_ops: Mapping[str, Mapping[int, int]] | None = None
+        ) -> set[frozenset[int]]:
     """Enumerate single-bond subsets of bonds 
     excluding disconnected ones and symmetry-equivalent ones.
     """
-    found: set[frozenset[str]] = set()
+    found: set[frozenset[int]] = set()
 
     # NOTE: The order of the iteration should be fixed to make the
     # result deterministic.

--- a/recsa/bondset_enumeration/lib/symmetry_application.py
+++ b/recsa/bondset_enumeration/lib/symmetry_application.py
@@ -4,8 +4,8 @@ __all__ = ['apply_symmetry_operation']
 
 
 def apply_symmetry_operation(
-        bondset: Iterable[str],
-        sym_op: Mapping[str, str]
-        ) -> set[str]:
+        bondset: Iterable[int],
+        sym_op: Mapping[int, int]
+        ) -> set[int]:
     """Apply a symmetry operation to an assembly."""
     return set(sym_op[bond] for bond in bondset)

--- a/recsa/bondset_enumeration/lib/tests/test_normalization.py
+++ b/recsa/bondset_enumeration/lib/tests/test_normalization.py
@@ -4,17 +4,17 @@ from recsa.bondset_enumeration import normalize_bondset_under_sym_ops
 
 
 def test_1():
-    BONDSET = {'01'}
-    SYM_OPS = {'foo': {'01': '02', '02': '01'}}
+    BONDSET = {1}
+    SYM_OPS = {'foo': {1: 2, 2: 1}}
     result = normalize_bondset_under_sym_ops(BONDSET, SYM_OPS)
-    assert result == {'01'}
+    assert result == {1}
 
 
 def test_2():
-    BONDSET = {'02'}
-    SYM_OPS = {'foo': {'01': '02', '02': '01'}}
+    BONDSET = {2}
+    SYM_OPS = {'foo': {1: 2, 2: 1}}
     result = normalize_bondset_under_sym_ops(BONDSET, SYM_OPS)
-    assert result == {'01'}
+    assert result == {1}
 
 
 if __name__ == '__main__':

--- a/recsa/bondset_enumeration/tests/test_core.py
+++ b/recsa/bondset_enumeration/tests/test_core.py
@@ -8,40 +8,40 @@ def test_enum_bond_subsets_linear_M2L3():
     # bonds: 1, 2, 3, 4 from left to right
 
     # WITHOUT symmetry operations
-    BONDS = ['1', '2', '3', '4']
+    BONDS = [1, 2, 3, 4]
     BOND_TO_ADJ_BONDS = {
-        '1': {'2'},
-        '2': {'1', '3'},
-        '3': {'2', '4'},
-        '4': {'3'},
+        1: {2},
+        2: {1, 3},
+        3: {2, 4},
+        4: {3},
     }
 
     subsets = enum_bond_subsets(BONDS, BOND_TO_ADJ_BONDS)
     
     assert subsets == {
-        frozenset({'1'}),
-        frozenset({'2'}),
-        frozenset({'3'}),
-        frozenset({'4'}),
-        frozenset({'1', '2'}),
-        frozenset({'2', '3'}),
-        frozenset({'3', '4'}),
-        frozenset({'1', '2', '3'}),
-        frozenset({'2', '3', '4'}),
-        frozenset({'1', '2', '3', '4'}),
+        frozenset({1}),
+        frozenset({2}),
+        frozenset({3}),
+        frozenset({4}),
+        frozenset({1, 2}),
+        frozenset({2, 3}),
+        frozenset({3, 4}),
+        frozenset({1, 2, 3}),
+        frozenset({2, 3, 4}),
+        frozenset({1, 2, 3, 4}),
     }
 
     # WITH symmetry operations
     SYM_OPS = {
-        'C2': {'1': '4', '2': '3', '3': '2', '4': '1'}
+        'C2': {1: 4, 2: 3, 3: 2, 4: 1}
     }
     EXPECTED = {
-        frozenset({'1'}),
-        frozenset({'2'}),
-        frozenset({'1', '2'}),
-        frozenset({'2', '3'}),
-        frozenset({'1', '2', '3'}),
-        frozenset({'1', '2', '3', '4'}),
+        frozenset({1}),
+        frozenset({2}),
+        frozenset({1, 2}),
+        frozenset({2, 3}),
+        frozenset({1, 2, 3}),
+        frozenset({1, 2, 3, 4}),
     }
     assert EXPECTED == enum_bond_subsets(
         BONDS, BOND_TO_ADJ_BONDS, SYM_OPS)
@@ -49,23 +49,23 @@ def test_enum_bond_subsets_linear_M2L3():
 
 def test_enum_bond_subsets_triangle():
     # Triangle with three bonds: 1, 2, 3
-    BONDS = ['1', '2', '3']
+    BONDS = [1, 2, 3]
     BOND_TO_ADJ_BONDS = {
-        '1': {'2', '3'},
-        '2': {'1', '3'},
-        '3': {'1', '2'}
+        1: {2, 3},
+        2: {1, 3},
+        3: {1, 2}
     }
     SYM_OPS = {
-        'C3': {'1': '2', '2': '3', '3': '1'},
-        'C3^2': {'1': '3', '2': '1', '3': '2'},
-        'sigma1': {'1': '1', '2': '3', '3': '2'},
-        'sigma2': {'1': '2', '2': '1', '3': '3'},
-        'sigma3': {'1': '3', '2': '2', '3': '1'}
+        'C3': {1: 2, 2: 3, 3: 1},
+        'C3^2': {1: 3, 2: 1, 3: 2},
+        'sigma1': {1: 1, 2: 3, 3: 2},
+        'sigma2': {1: 2, 2: 1, 3: 3},
+        'sigma3': {1: 3, 2: 2, 3: 1}
     }
     EXPECTED = {
-        frozenset({'1'}),
-        frozenset({'1', '2'}),
-        frozenset({'1', '2', '3'})
+        frozenset({1}),
+        frozenset({1, 2}),
+        frozenset({1, 2, 3})
     }
     assert EXPECTED == enum_bond_subsets(BONDS, BOND_TO_ADJ_BONDS, SYM_OPS)
 
@@ -84,50 +84,50 @@ def test_enum_bond_subsets_M4L4_square():
     #  |             |
     #  M1-(1)-L1-(2)-M2
 
-    BONDS = ['1', '2', '3', '4', '5', '6', '7', '8']
+    BONDS = [1, 2, 3, 4, 5, 6, 7, 8]
     BOND_TO_ADJ_BONDS = {
-        '1': {'8', '2'},
-        '2': {'1', '3'},
-        '3': {'2', '4'},
-        '4': {'3', '5'},
-        '5': {'4', '6'},
-        '6': {'5', '7'},
-        '7': {'6', '8'},
-        '8': {'7', '1'},
+        1: {8, 2},
+        2: {1, 3},
+        3: {2, 4},
+        4: {3, 5},
+        5: {4, 6},
+        6: {5, 7},
+        7: {6, 8},
+        8: {7, 1},
     }
     SYMMETRY_OPS = {
         'C_4': {
-            '1': '3', '2': '4', '3': '5', '4': '6',
-            '5': '7', '6': '8', '7': '1', '8': '2'},
+            1: 3, 2: 4, 3: 5, 4: 6,
+            5: 7, 6: 8, 7: 1, 8: 2},
         'C_2': {
-            '1': '5', '2': '6', '3': '7', '4': '8',
-            '5': '1', '6': '2', '7': '3', '8': '4'},
+            1: 5, 2: 6, 3: 7, 4: 8,
+            5: 1, 6: 2, 7: 3, 8: 4},
         'C_4^3': {
-            '1': '7', '2': '8', '3': '1', '4': '2',
-            '5': '3', '6': '4', '7': '5', '8': '6'},
+            1: 7, 2: 8, 3: 1, 4: 2,
+            5: 3, 6: 4, 7: 5, 8: 6},
         'C_2x': {
-            '1': '2', '2': '1', '3': '8', '4': '7',
-            '5': '6', '6': '5', '7': '4', '8': '3'},
+            1: 2, 2: 1, 3: 8, 4: 7,
+            5: 6, 6: 5, 7: 4, 8: 3},
         'C_2y': {
-            '1': '6', '2': '5', '3': '4', '4': '3',
-            '5': '2', '6': '1', '7': '8', '8': '7'},
+            1: 6, 2: 5, 3: 4, 4: 3,
+            5: 2, 6: 1, 7: 8, 8: 7},
         'C_2(1)': {
-            '1': '4', '2': '3', '3': '2', '4': '1',
-            '5': '8', '6': '7', '7': '6', '8': '5'},
+            1: 4, 2: 3, 3: 2, 4: 1,
+            5: 8, 6: 7, 7: 6, 8: 5},
         'C_2(2)': {
-            '1': '8', '2': '7', '3': '6', '4': '5',
-            '5': '4', '6': '3', '7': '2', '8': '1'},
+            1: 8, 2: 7, 3: 6, 4: 5,
+            5: 4, 6: 3, 7: 2, 8: 1},
     }
     EXPECTED = {
-        frozenset({'1'}),
-        frozenset({'1', '2'}), frozenset({'1', '8'}),
-        frozenset({'1', '2', '3'}),
-        frozenset({'1', '2', '3', '4'}), frozenset({'1', '2', '3', '8'}),
-        frozenset({'1', '2', '3', '4', '5'}),
-        frozenset({'1', '2', '3', '4', '5', '6'}),
-        frozenset({'1', '2', '3', '4', '5', '8'}),
-        frozenset({'1', '2', '3', '4', '5', '6', '7'}),
-        frozenset({'1', '2', '3', '4', '5', '6', '7', '8'}),
+        frozenset({1}),
+        frozenset({1, 2}), frozenset({1, 8}),
+        frozenset({1, 2, 3}),
+        frozenset({1, 2, 3, 4}), frozenset({1, 2, 3, 8}),
+        frozenset({1, 2, 3, 4, 5}),
+        frozenset({1, 2, 3, 4, 5, 6}),
+        frozenset({1, 2, 3, 4, 5, 8}),
+        frozenset({1, 2, 3, 4, 5, 6, 7}),
+        frozenset({1, 2, 3, 4, 5, 6, 7, 8}),
     }
 
     assert enum_bond_subsets(

--- a/recsa/debug_utils/bondsets_comparer.py
+++ b/recsa/debug_utils/bondsets_comparer.py
@@ -10,9 +10,9 @@ class BondsetsComparer:
     """Compare bondsets under symmetry operations."""
     def __init__(
             self,
-            first_bondsets: Iterable[Iterable[str]],
-            second_bondsets: Iterable[Iterable[str]],
-            sym_ops: Mapping[str, Mapping[str, str]] | None = None,
+            first_bondsets: Iterable[Iterable[int]],
+            second_bondsets: Iterable[Iterable[int]],
+            sym_ops: Mapping[str, Mapping[int, int]] | None = None,
             ) -> None:
         first_bondsets = list(first_bondsets)
         second_bondsets = list(second_bondsets)
@@ -25,11 +25,11 @@ class BondsetsComparer:
         self.sym_ops = sym_ops
 
     @property
-    def first_bondsets(self) -> set[frozenset[str]]:
+    def first_bondsets(self) -> set[frozenset[int]]:
         return self._first_bondsets
     
     @property
-    def second_bondsets(self) -> set[frozenset[str]]:
+    def second_bondsets(self) -> set[frozenset[int]]:
         return self._second_bondsets
 
     @cached_property
@@ -37,15 +37,15 @@ class BondsetsComparer:
         return not self.only_in_first and not self.only_in_second
     
     @cached_property
-    def only_in_first(self) -> set[frozenset[str]]:
+    def only_in_first(self) -> set[frozenset[int]]:
         return self.first_bondsets - self.first_to_second.keys()
     
     @cached_property
-    def only_in_second(self) -> set[frozenset[str]]:
+    def only_in_second(self) -> set[frozenset[int]]:
         return self.second_bondsets - self.second_to_first.keys()
     
     @cached_property
-    def first_to_second(self) -> dict[frozenset[str], frozenset[str]]:
+    def first_to_second(self) -> dict[frozenset[int], frozenset[int]]:
         return {
             first: self.normalized_to_second[normalized]
             for first, normalized in self.first_to_normalized.items()
@@ -53,7 +53,7 @@ class BondsetsComparer:
             }
     
     @cached_property
-    def second_to_first(self) -> dict[frozenset[str], frozenset[str]]:
+    def second_to_first(self) -> dict[frozenset[int], frozenset[int]]:
         return {
             second: self.normalized_to_first[normalized]
             for second, normalized in self.second_to_normalized.items()
@@ -61,15 +61,15 @@ class BondsetsComparer:
             }
     
     @cached_property
-    def first_to_normalized(self) -> dict[frozenset[str], frozenset[str]]:
+    def first_to_normalized(self) -> dict[frozenset[int], frozenset[int]]:
         return _bondsets_to_normalized(self.first_bondsets, self.sym_ops)
     
     @cached_property
-    def second_to_normalized(self) -> dict[frozenset[str], frozenset[str]]:
+    def second_to_normalized(self) -> dict[frozenset[int], frozenset[int]]:
         return _bondsets_to_normalized(self.second_bondsets, self.sym_ops)
     
     @cached_property
-    def normalized_to_first(self) -> dict[frozenset[str], frozenset[str]]:
+    def normalized_to_first(self) -> dict[frozenset[int], frozenset[int]]:
         # Assert that there are no duplicate normalized bondsets,
         # i.e., there are no duplicate values in self.first_to_normalized.
         unique_normalized = set(self.first_to_normalized.values())
@@ -77,7 +77,7 @@ class BondsetsComparer:
         return {v: k for k, v in self.first_to_normalized.items()}
     
     @cached_property
-    def normalized_to_second(self) -> dict[frozenset[str], frozenset[str]]:
+    def normalized_to_second(self) -> dict[frozenset[int], frozenset[int]]:
         # Assert that there are no duplicate normalized bondsets.
         unique_normalized = set(self.second_to_normalized.values())
         assert len(unique_normalized) == len(self.second_to_normalized)
@@ -85,9 +85,9 @@ class BondsetsComparer:
 
 
 def _bondsets_to_normalized(
-        bondsets: Iterable[Iterable[str]],
-        sym_ops: Mapping[str, Mapping[str, str]] | None = None
-        ) -> dict[frozenset[str], frozenset[str]]:
+        bondsets: Iterable[Iterable[int]],
+        sym_ops: Mapping[str, Mapping[int, int]] | None = None
+        ) -> dict[frozenset[int], frozenset[int]]:
     return {
         frozenset(bondset): frozenset(normalize_bondset_under_sym_ops(
             bondset, sym_ops))

--- a/recsa/debug_utils/bondsets_validation.py
+++ b/recsa/debug_utils/bondsets_validation.py
@@ -3,7 +3,7 @@ from typing import TypeVar
 
 
 def validate_bondsets(
-        bondsets: Iterable[Iterable[str]]
+        bondsets: Iterable[Iterable[int]]
         ) -> None:
     """Validate bondsets.
 
@@ -11,7 +11,7 @@ def validate_bondsets(
 
     Parameters
     ----------
-    bondsets : Iterable[Iterable[str]]
+    bondsets : Iterable[Iterable[int]]
         Bondsets to validate.
 
     Raises

--- a/recsa/debug_utils/tests/test_bondsets_comparer.py
+++ b/recsa/debug_utils/tests/test_bondsets_comparer.py
@@ -13,41 +13,41 @@ from recsa.debug_utils import BondsetsComparer
 #         M2
 
 def test_equal():
-    FIRST_BONDSETS = [['1'], ['1', '2']]
-    SECOND_BONDSETS = [['1'], ['2', '1']]
+    FIRST_BONDSETS = [[1], [1, 2]]
+    SECOND_BONDSETS = [[1], [2, 1]]
     comparer = BondsetsComparer(FIRST_BONDSETS, SECOND_BONDSETS)
     assert comparer.are_equal
 
 
 def test_inequal():
-    FIRST_BONDSETS = [['1'], ['1', '2']]
-    SECOND_BONDSETS = [['1'], ['2', '3']]
+    FIRST_BONDSETS = [[1], [1, 2]]
+    SECOND_BONDSETS = [[1], [2, 3]]
     comparer = BondsetsComparer(FIRST_BONDSETS, SECOND_BONDSETS)
     assert not comparer.are_equal
 
 
 def test_equal_with_sym_ops():
-    FIRST_BONDSETS = [['1'], ['1', '2']]
-    SECOND_BONDSETS = [['2'], ['3', '4']]
+    FIRST_BONDSETS = [[1], [1, 2]]
+    SECOND_BONDSETS = [[2], [3, 4]]
     SYM_OPS = {
-        'sigma': {'1': '2', '2': '1', '3': '4', '4': '3'},  # [1] -> [2]
-        'C2': {'1': '3', '2': '4', '3': '1', '4': '2'},  # [1, 2] -> [3, 4]
+        'sigma': {1: 2, 2: 1, 3: 4, 4: 3},  # [1] -> [2]
+        'C2': {1: 3, 2: 4, 3: 1, 4: 2},  # [1, 2] -> [3, 4]
         }
     comparer = BondsetsComparer(FIRST_BONDSETS, SECOND_BONDSETS, SYM_OPS)
     assert comparer.are_equal
 
 
 def test_mapping_and_diffs():
-    FIRST_BONDSETS = [['1'], ['1', '2']]
-    SECOND_BONDSETS = [['2'], ['2', '3']]
+    FIRST_BONDSETS = [[1], [1, 2]]
+    SECOND_BONDSETS = [[2], [2, 3]]
     SYM_OPS = {
-        'sigma': {'1': '2', '2': '1', '3': '4', '4': '3'},  # [1] -> [2]
-        'C2': {'1': '3', '2': '4', '3': '1', '4': '2'},  # [1, 2] -> [3, 4]
+        'sigma': {1: 2, 2: 1, 3: 4, 4: 3},  # [1] -> [2]
+        'C2': {1: 3, 2: 4, 3: 1, 4: 2},  # [1, 2] -> [3, 4]
         }
     comparer = BondsetsComparer(FIRST_BONDSETS, SECOND_BONDSETS, SYM_OPS)
-    assert comparer.first_to_second == {frozenset(['1']): frozenset(['2'])}
-    assert comparer.only_in_first == {frozenset(['1', '2'])}
-    assert comparer.only_in_second == {frozenset(['2', '3'])}
+    assert comparer.first_to_second == {frozenset([1]): frozenset([2])}
+    assert comparer.only_in_first == {frozenset([1, 2])}
+    assert comparer.only_in_second == {frozenset([2, 3])}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request involves a significant refactor of the bondset enumeration module, focusing on changing the type of bond identifiers from strings to integers across various functions and their corresponding tests. The main changes include modifying function signatures, updating type annotations, and adjusting test cases to reflect these changes.

### Changes to bond identifier types:

* [`recsa/bondset_enumeration/core.py`](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L11-R14): Updated the `enum_bond_subsets` function to use integers instead of strings for bond identifiers. This change affects the function parameters, return type, and internal variable types. [[1]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L11-R14) [[2]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L47-R55) [[3]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L67-L75) [[4]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L122-R117)
* [`recsa/bondset_enumeration/lib/is_new_check.py`](diffhunk://#diff-44c367c569860af708820ae941a828655ae31ed27f10d4a607d1e1c16e4d3549L9-R11): Modified the `is_new_under_symmetry` function to use integers for bond identifiers.
* [`recsa/bondset_enumeration/lib/multi_bond.py`](diffhunk://#diff-e190f874c1eada4e0c6786d12df616a1318a2e54f0580bed40f39050090b822dL11-R28): Changed the `enum_multi_bond_subsets` function to use integers for bond identifiers.
* [`recsa/bondset_enumeration/lib/normalization.py`](diffhunk://#diff-91d83a219c837579466d41f27a2bab8901889865d68b1f0877ca7c85cf7eb2c8L9-R11): Updated the `normalize_bondset_under_sym_ops` function to use integers for bond identifiers.
* [`recsa/bondset_enumeration/lib/single_bond.py`](diffhunk://#diff-a5d34eaa3d68d81d1dbce4e85222ecd10d86d68b6f480c260dc61c17f71fb61bL9-R15): Modified the `enum_single_bond_subsets` function to use integers for bond identifiers.
* [`recsa/bondset_enumeration/lib/symmetry_application.py`](diffhunk://#diff-7c749a6e0b3d9b66ced852fb896016fd6044b6dcfccb7d3cd0ec5d431a839efeL7-R9): Changed the `apply_symmetry_operation` function to use integers for bond identifiers.

### Changes to test cases:

* [`recsa/bondset_enumeration/tests/test_core.py`](diffhunk://#diff-54552e9b9ffc797019e2b1dd55980b3d4bf2d9155b48ca19d46825c4184e9889L11-R68): Updated test cases to use integers for bond identifiers in `test_enum_bond_subsets_linear_M2L3`, `test_enum_bond_subsets_triangle`, and `test_enum_bond_subsets_M4L4_square`. [[1]](diffhunk://#diff-54552e9b9ffc797019e2b1dd55980b3d4bf2d9155b48ca19d46825c4184e9889L11-R68) [[2]](diffhunk://#diff-54552e9b9ffc797019e2b1dd55980b3d4bf2d9155b48ca19d46825c4184e9889L87-R130)
* [`recsa/bondset_enumeration/lib/tests/test_normalization.py`](diffhunk://#diff-030453e605ebc70325e115dc25b25b22c7b70111d13782fb3771d9e4c4e63577L7-R17): Modified test cases to use integers for bond identifiers.
* [`recsa/debug_utils/tests/test_bondsets_comparer.py`](diffhunk://#diff-3ae603191f03f0cde051b81bb1fdb0e1a20beef894b86c92cec436e09fe56041L16-R50): Updated test cases to use integers for bond identifiers.

### Changes to utility classes:

* [`recsa/debug_utils/bondsets_comparer.py`](diffhunk://#diff-68e12e8c8537afe9ce22ec1f98555be15dda49e2a717423086011195455e4bd1L13-R15): Updated the `BondsetsComparer` class to use integers for bond identifiers in its methods and properties. [[1]](diffhunk://#diff-68e12e8c8537afe9ce22ec1f98555be15dda49e2a717423086011195455e4bd1L13-R15) [[2]](diffhunk://#diff-68e12e8c8537afe9ce22ec1f98555be15dda49e2a717423086011195455e4bd1L28-R90)
* [`recsa/debug_utils/bondsets_validation.py`](diffhunk://#diff-f7859f932e680a95f10edf9d518ae2e34661eb5391d1a99d6742d284a5550768L6-R14): Changed the `validate_bondsets` function to use integers for bond identifiers.