### PR TITLE
Add shortest path search utility and corresponding tests

### DIFF
--- a/recsa/reaction_classification/utils/__init__.py
+++ b/recsa/reaction_classification/utils/__init__.py
@@ -1,3 +1,4 @@
 from .connected_comp_count import count_connected
 from .inter_or_intra_judgement import inter_or_intra
 from .shortest_cycle_search import find_shortest_cycle
+from .shortest_path_search import find_shortest_path

--- a/recsa/reaction_classification/utils/shortest_path_search.py
+++ b/recsa/reaction_classification/utils/shortest_path_search.py
@@ -1,0 +1,38 @@
+from math import inf
+
+import networkx as nx
+
+from recsa import Assembly
+
+
+def find_shortest_path(
+        assembly: Assembly,
+        comp_id1: str, comp_id2: str,
+        ) -> list | None:
+    """Find one of the shortest paths between two components in the assembly.
+
+    Parameters
+    ----------
+    assembly : Assembly
+        The assembly object.
+    comp_id1 : str
+        The component ID of the first component.
+    comp_id2 : str
+        The component ID of the second component.
+
+    Returns
+    -------
+    list | None
+        The list of component IDs in the shortest path between the two components.
+        If no path exists, return None.
+    """
+    if comp_id1 not in assembly.component_ids:
+        raise ValueError(f"Component {comp_id1} is not in the assembly")
+    if comp_id2 not in assembly.component_ids:
+        raise ValueError(f"Component {comp_id2} is not in the assembly")
+    g = assembly.rough_g_snapshot
+    try:
+        path = nx.shortest_path(g, comp_id1, comp_id2)
+        return path
+    except nx.NetworkXNoPath:
+        return None

--- a/recsa/reaction_classification/utils/tests/test_shortest_path_search.py
+++ b/recsa/reaction_classification/utils/tests/test_shortest_path_search.py
@@ -1,0 +1,39 @@
+import pytest
+
+from recsa import Assembly
+from recsa.reaction_classification.utils import find_shortest_path
+
+
+def test():
+    assembly = Assembly()
+    assembly.add_components([('M0', 'M'), ('L0', 'L'), ('X0', 'X')])
+    assembly.add_bonds([('M0.a', 'L0.a'), ('M0.b', 'X0.a')])
+
+    assert find_shortest_path(assembly, 'M0', 'X0') == ['M0', 'X0']
+    assert find_shortest_path(assembly, 'M0', 'L0') == ['M0', 'L0']
+    assert find_shortest_path(assembly, 'L0', 'X0') == ['L0', 'M0', 'X0']
+
+
+def test_no_path():
+    assembly = Assembly()
+    assembly.add_components([('M0', 'M'), ('L0', 'L'), ('X0', 'X')])
+    assembly.add_bonds([('M0.a', 'L0.a')])
+
+    assert find_shortest_path(assembly, 'M0', 'X0') is None
+    assert find_shortest_path(assembly, 'M0', 'L0') == ['M0', 'L0']
+    assert find_shortest_path(assembly, 'L0', 'X0') is None
+
+
+def test_not_in_assembly():
+    assembly = Assembly()
+    assembly.add_components([('M0', 'M'), ('L0', 'L'), ('X0', 'X')])
+    assembly.add_bonds([('M0.a', 'L0.a')])
+
+    with pytest.raises(ValueError):
+        find_shortest_path(assembly, 'M0', 'Y0')
+    with pytest.raises(ValueError):
+        find_shortest_path(assembly, 'Y0', 'M0')
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new utility function to find the shortest path between two components in an assembly and includes associated tests. The main changes are the addition of the `find_shortest_path` function and the corresponding tests.

New functionality:

* [`recsa/reaction_classification/utils/__init__.py`](diffhunk://#diff-801480c79bf25951a7dee3e75dfcd842888c3a045976938ac33285f053b45c81R4): Added import for `find_shortest_path` function.
* [`recsa/reaction_classification/utils/shortest_path_search.py`](diffhunk://#diff-2c8ddd8f56feb261d7c99264bff107d23fb9b12285784f78bb60b1e5fcc79ad3R1-R38): Implemented `find_shortest_path` function to determine the shortest path between two components in an assembly using NetworkX.

Testing:

* [`recsa/reaction_classification/utils/tests/test_shortest_path_search.py`](diffhunk://#diff-3badce27e62a044013d12c40914817833290b185bbd71e7f7a42dcd0be7031f9R1-R39): Added tests for the `find_shortest_path` function, including cases for valid paths, no paths, and components not in the assembly.