### PR TITLE
Refactor binding site terminology in Component and related classes

### DIFF
--- a/recsa/classes/assembly.py
+++ b/recsa/classes/assembly.py
@@ -332,7 +332,7 @@ class Assembly(yaml.YAMLObject):
         all_bindsites = set()
         for comp_id, comp_kind in self.comp_id_to_kind.items():
             comp_struct = component_structures[comp_kind]
-            for bindsite in comp_struct.bindsites:
+            for bindsite in comp_struct.binding_sites:
                 all_bindsites.add(id_converter.local_to_global(comp_id, bindsite))
         return all_bindsites
 
@@ -345,9 +345,9 @@ class Assembly(yaml.YAMLObject):
             for rel_aux_edge in comp_struct.aux_edges:
                 yield AbsAuxEdge(
                     id_converter.local_to_global(
-                        comp_id, rel_aux_edge.local_bindsite1),
+                        comp_id, rel_aux_edge.local_binding_site1),
                     id_converter.local_to_global(
-                        comp_id, rel_aux_edge.local_bindsite2),
+                        comp_id, rel_aux_edge.local_binding_site2),
                     rel_aux_edge.aux_kind)
 
     def get_bindsites_of_component(
@@ -360,7 +360,7 @@ class Assembly(yaml.YAMLObject):
         comp_struct = component_structures[comp_kind]
         return {
             id_converter.local_to_global(component_id, bindsite)
-            for bindsite in comp_struct.bindsites}
+            for bindsite in comp_struct.binding_sites}
     
     def get_all_bindsites_of_kind(
             self, component_kind: str,
@@ -379,7 +379,7 @@ class Assembly(yaml.YAMLObject):
         all_bindsites = {
             id_converter.local_to_global(comp_id, bindsite)
             for comp_id, comp_kind in self.comp_id_to_kind.items()
-            for bindsite in component_structures[comp_kind].bindsites
+            for bindsite in component_structures[comp_kind].binding_sites
         }
         connected_bindsites = chain(*self.bonds)
         free_bindsites = all_bindsites - set(connected_bindsites)
@@ -467,13 +467,13 @@ def add_component_to_graph(
         core_abs, core_or_bindsite='core', component_kind=component_kind)
     
     # Add the binding sites
-    for bindsite in component_structure.bindsites:
+    for bindsite in component_structure.binding_sites:
         bindsite_abs = id_converter.local_to_global(component_id, bindsite)
         g.add_node(bindsite_abs, core_or_bindsite='bindsite')
         g.add_edge(core_abs, bindsite_abs)
     
     # Add the auxiliary edges
     for aux_edge in component_structure.aux_edges:
-        bs1_abs = id_converter.local_to_global(component_id, aux_edge.local_bindsite1)
-        bs2_abs = id_converter.local_to_global(component_id, aux_edge.local_bindsite2)
+        bs1_abs = id_converter.local_to_global(component_id, aux_edge.local_binding_site1)
+        bs2_abs = id_converter.local_to_global(component_id, aux_edge.local_binding_site2)
         g.add_edge(bs1_abs, bs2_abs, aux_type=aux_edge.aux_kind)

--- a/recsa/classes/aux_edge.py
+++ b/recsa/classes/aux_edge.py
@@ -19,7 +19,8 @@ class AuxEdge(yaml.YAMLObject):
     yaml_flow_style = None
 
     def __init__(
-            self, local_bindsite1: str, local_bindsite2: str, aux_kind: str):
+            self, local_binding_site1: str, local_binding_site2: str, 
+            aux_kind: str):
         """Initialize an auxiliary edge.
 
         Note that the order of the binding sites does not matter,
@@ -27,11 +28,11 @@ class AuxEdge(yaml.YAMLObject):
 
         Parameters
         ----------
-        bindsite1 : str
+        local_binding_site1 : str
             The local id of the first binding site.
-        bindsite2 : str
+        local_binding_site2 : str
             The local id of the second binding site.
-        aux_type : str
+        aux_kind : str
             The auxiliary type.
 
         Note
@@ -43,60 +44,60 @@ class AuxEdge(yaml.YAMLObject):
         rx.RecsaValueError
             If the two binding sites are the same.
         """
-        validate_name_of_binding_site(local_bindsite1)
-        validate_name_of_binding_site(local_bindsite2)
-        if local_bindsite1 == local_bindsite2:
+        validate_name_of_binding_site(local_binding_site1)
+        validate_name_of_binding_site(local_binding_site2)
+        if local_binding_site1 == local_binding_site2:
             raise rx.RecsaValueError(
                 'The two binding sites should be different.')
-        self._bindsites = FrozenUnorderedPair[str](
-            local_bindsite1, local_bindsite2)
+        self._binding_sites = FrozenUnorderedPair[str](
+            local_binding_site1, local_binding_site2)
 
         validate_name_of_aux_type(aux_kind)
         self._aux_kind = aux_kind
     
     @property
-    def local_bindsite1(self) -> str:
-        return self._bindsites.first
+    def local_binding_site1(self) -> str:
+        return self._binding_sites.first
     
     @property
-    def local_bindsite2(self) -> str:
-        return self._bindsites.second
+    def local_binding_site2(self) -> str:
+        return self._binding_sites.second
     
     @property
-    def bindsites(self) -> FrozenUnorderedPair[str]:
-        return self._bindsites
+    def binding_sites(self) -> FrozenUnorderedPair[str]:
+        return self._binding_sites
 
     @property
     def aux_kind(self) -> str:
         return self._aux_kind
 
     def __hash__(self) -> int:
-        return hash((self.bindsites, self.aux_kind))
+        return hash((self.binding_sites, self.aux_kind))
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, AuxEdge):
             return False
         return (
-            self.bindsites == other.bindsites and
+            self.binding_sites == other.binding_sites and
             self.aux_kind == other.aux_kind)
     
     def __lt__(self, other: 'AuxEdge') -> bool:
-        return (sorted(self.bindsites), self.aux_kind) < (
-            sorted(other.bindsites), other.aux_kind)
+        return (sorted(self.binding_sites), self.aux_kind) < (
+            sorted(other.binding_sites), other.aux_kind)
     
     def __repr__(self) -> str:
-        return f'AuxEdge({self.local_bindsite1!r}, {self.local_bindsite2!r}, {self.aux_kind!r})'
+        return f'AuxEdge({self.local_binding_site1!r}, {self.local_binding_site2!r}, {self.aux_kind!r})'
     
     @classmethod
     def from_yaml(cls, loader, node):
         data = loader.construct_mapping(node, deep=True)
         return AuxEdge(
-            data['bindsites'][0], data['bindsites'][1], data['aux_kind'])
+            data['binding_sites'][0], data['binding_sites'][1], data['aux_kind'])
 
     @classmethod
     def to_yaml(cls, dumper, data):
         return dumper.represent_mapping(
             cls.yaml_tag, {
-            'bindsites': sorted(data.bindsites),
+            'binding_sites': sorted(data.binding_sites),
             'aux_kind': data.aux_kind},
             flow_style=cls.yaml_flow_style)

--- a/recsa/classes/component/bindsite_existence_check.py
+++ b/recsa/classes/component/bindsite_existence_check.py
@@ -14,7 +14,7 @@ def check_bindsites_of_aux_edges_exists(
     binding sites of the component.
     """
     for aux_edge in aux_edges:
-        for bindsite in aux_edge.bindsites:
+        for bindsite in aux_edge.binding_sites:
             if bindsite not in bindsites:
                 raise RecsaValueError(
                     f'The binding site "{bindsite}" is not in '

--- a/recsa/classes/component/component.py
+++ b/recsa/classes/component/component.py
@@ -19,7 +19,7 @@ class Component(yaml.YAMLObject):
 
     def __init__(
             self,
-            bindsites: Iterable[str],
+            binding_sites: Iterable[str],
             aux_edges: (
                 Iterable[AuxEdge] 
                 | Iterable[tuple[str, str, str]] | None
@@ -38,9 +38,9 @@ class Component(yaml.YAMLObject):
             Duplicate pairs of binding sites raise an error regardless of the
             order of the binding sites.
         """
-        for bindsite in bindsites:
-            validate_name_of_binding_site(bindsite)
-        self._bindsites = frozenset(bindsites)
+        for binding_site in binding_sites:
+            validate_name_of_binding_site(binding_site)
+        self._binding_sites = frozenset(binding_sites)
 
         if aux_edges is None:
             self._aux_edges = frozenset[AuxEdge]()
@@ -53,26 +53,26 @@ class Component(yaml.YAMLObject):
                 {AuxEdge(*edge) for edge in aux_edges})
 
         check_bindsites_of_aux_edges_exists(
-            self._aux_edges, self._bindsites)
+            self._aux_edges, self._binding_sites)
     
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, Component):
             return False
         return (
-            self.bindsites == value.bindsites
+            self.binding_sites == value.binding_sites
             and self.aux_edges == value.aux_edges)
     
     def __repr__(self) -> str:
         if not self.aux_edges:
-            return f'Component({sorted(self.bindsites)!r})'
+            return f'Component({sorted(self.binding_sites)!r})'
         return (
-            f'Component({sorted(self.bindsites)!r}, '
+            f'Component({sorted(self.binding_sites)!r}, '
             f'{sorted(self.aux_edges)!r})'
             )
     
     @property
-    def bindsites(self) -> set[str]:
-        return set(self._bindsites)
+    def binding_sites(self) -> set[str]:
+        return set(self._binding_sites)
 
     @property
     def aux_edges(self) -> set[AuxEdge]:
@@ -81,17 +81,17 @@ class Component(yaml.YAMLObject):
     @classmethod
     def from_yaml(cls, loader, node):
         data = loader.construct_mapping(node, deep=True)
-        bindsites = data['bindsites']
+        binding_sites = data['binding_sites']
         aux_edges = data.get('aux_edges', None)
-        return cls(bindsites, aux_edges)
+        return cls(binding_sites, aux_edges)
 
     @classmethod
     def to_yaml(cls, dumper, data):
-        data_dict = {'bindsites': sorted(data.bindsites)}
+        data_dict = {'binding_sites': sorted(data.binding_sites)}
         if data.aux_edges:
             data_dict['aux_edges'] = sorted(
                 data.aux_edges,
-                key=lambda edge: sorted(edge.bindsites))
+                key=lambda edge: sorted(edge.binding_sites))
         return dumper.represent_mapping(
             cls.yaml_tag, data_dict,
             flow_style=cls.yaml_flow_style)

--- a/recsa/classes/component/tests/test_component.py
+++ b/recsa/classes/component/tests/test_component.py
@@ -6,48 +6,48 @@ from recsa import AuxEdge, Component
 
 
 def test_typical_usage():
-    bindsites = ['a', 'b', 'c', 'd']
+    binding_sites = ['a', 'b', 'c', 'd']
     aux_edges = [('a', 'b', 'cis'), ('b', 'c', 'cis'),
                  ('c', 'd', 'cis'), ('d', 'a', 'cis')]
-    M = Component(bindsites, aux_edges)
-    assert M.bindsites == set(bindsites)
+    M = Component(binding_sites, aux_edges)
+    assert M.binding_sites == set(binding_sites)
     assert M.aux_edges == {AuxEdge(*edge) for edge in aux_edges}
 
 
 def test_init():
-    bindsites = {'a', 'b'}
-    M = Component(bindsites)
-    assert M.bindsites == bindsites
+    binding_sites = {'a', 'b'}
+    M = Component(binding_sites)
+    assert M.binding_sites == binding_sites
     assert M.aux_edges == set()
 
 
-def test_init_with_bindsites_of_type_tuple():
-    bindsites = ['a', 'b']
-    M = Component(bindsites)
-    assert M.bindsites == set(bindsites)
+def test_init_with_binding_sites_of_type_tuple():
+    binding_sites = ['a', 'b']
+    M = Component(binding_sites)
+    assert M.binding_sites == set(binding_sites)
     assert M.aux_edges == set()
 
 
 def test_init_with_aux_edges():
-    bindsites = {'a', 'b'}
+    binding_sites = {'a', 'b'}
     aux_edges = {AuxEdge('a', 'b', 'cis')}
-    M = Component(bindsites, aux_edges)
-    assert M.bindsites == bindsites
+    M = Component(binding_sites, aux_edges)
+    assert M.binding_sites == binding_sites
     assert M.aux_edges == aux_edges
 
 
 def test_init_with_aux_edges_of_type_tuple():
-    bindsites = {'a', 'b'}
+    binding_sites = {'a', 'b'}
     aux_edges = [('a', 'b', 'cis')]
-    M = Component(bindsites, aux_edges)
-    assert M.bindsites == bindsites
+    M = Component(binding_sites, aux_edges)
+    assert M.binding_sites == binding_sites
     assert M.aux_edges == {AuxEdge(*edge) for edge in aux_edges}
 
 
 def test_init_with_empty_binding_sites():
     # Raises no error.
     M = Component(set())
-    assert M.bindsites == set()
+    assert M.binding_sites == set()
 
 
 def test_init_with_empty_aux_edges():

--- a/recsa/classes/tests/test_aux_edge.py
+++ b/recsa/classes/tests/test_aux_edge.py
@@ -7,8 +7,8 @@ from recsa import AuxEdge
 
 def test_LocalAuxEdge_initialization():
     edge = AuxEdge('site1', 'site2', 'cis')
-    assert edge.local_bindsite1 == 'site1'
-    assert edge.local_bindsite2 == 'site2'
+    assert edge.local_binding_site1 == 'site1'
+    assert edge.local_binding_site2 == 'site2'
     assert edge.aux_kind == 'cis'
 
 


### PR DESCRIPTION
This pull request includes several changes to improve consistency and clarity by renaming variables and method names related to binding sites across multiple files in the `recsa` package. The most important changes involve renaming `bindsites` to `binding_sites` and updating related method names and properties accordingly.

### Consistency Improvements:

* [`recsa/classes/assembly.py`](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L335-R335): Renamed `bindsites` to `binding_sites` in multiple methods to ensure consistent terminology. [[1]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L335-R335) [[2]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L348-R350) [[3]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L363-R363) [[4]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L382-R382) [[5]](diffhunk://#diff-db4a55e0e5e82b9108254f65d85bfd90a48cca2d0619b8fa0feb5f324f1ec104L470-R478)
* [`recsa/classes/aux_edge.py`](diffhunk://#diff-132570f2f242e928adc29ca143e6a26a3366f63df8141ac7b46d27f1b1fe605cL22-R35): Updated the `AuxEdge` class to use `local_binding_site1` and `local_binding_site2` instead of `local_bindsite1` and `local_bindsite2`, and renamed related properties and methods. [[1]](diffhunk://#diff-132570f2f242e928adc29ca143e6a26a3366f63df8141ac7b46d27f1b1fe605cL22-R35) [[2]](diffhunk://#diff-132570f2f242e928adc29ca143e6a26a3366f63df8141ac7b46d27f1b1fe605cL46-R101)
* [`recsa/classes/component/component.py`](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL22-R22): Changed `bindsites` to `binding_sites` in the `Component` class, including the constructor, properties, and related methods. [[1]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL22-R22) [[2]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL41-R43) [[3]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL56-R75) [[4]](diffhunk://#diff-9416b40d00a6a4c3f6d4dd7ba216b54fbd2278fe1dcdcc5034fe0833b5e7be2fL84-R94)
* [`recsa/classes/component/tests/test_component.py`](diffhunk://#diff-896fee91714289371c13eaff9aa9294c8523e5d4c7e92d5a82724170896093c6L9-R50): Updated test cases to reflect the renaming of `bindsites` to `binding_sites`.
* [`recsa/classes/tests/test_aux_edge.py`](diffhunk://#diff-b238afb34fb3c655cda3463ff52ea139ebff7cccad3071415e5cdf57913a003aL10-R11): Modified test cases to use the new `local_binding_site1` and `local_binding_site2` properties in the `AuxEdge` class.